### PR TITLE
docs: add XML documentation to TS4Tools.Wrappers public API

### DIFF
--- a/src/TS4Tools.Wrappers/CasPartResource/CaspEnums.cs
+++ b/src/TS4Tools.Wrappers/CasPartResource/CaspEnums.cs
@@ -11,7 +11,9 @@ namespace TS4Tools.Wrappers.CasPartResource;
 [SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "Legacy name compatibility")]
 public enum PackFlag : byte
 {
+    /// <summary>No flags set.</summary>
     None = 0,
+    /// <summary>Hide the pack icon in CAS.</summary>
     HidePackIcon = 1
 }
 
@@ -23,12 +25,19 @@ public enum PackFlag : byte
 [SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "Legacy name compatibility")]
 public enum ParmFlag : byte
 {
+    /// <summary>No flags set.</summary>
     None = 0,
+    /// <summary>Default part for body type.</summary>
     DefaultForBodyType = 1 << 0,
+    /// <summary>Default thumbnail part.</summary>
     DefaultThumbnailPart = 1 << 1,
+    /// <summary>Allow for random selection.</summary>
     AllowForRandom = 1 << 2,
+    /// <summary>Show in UI.</summary>
     ShowInUI = 1 << 3,
+    /// <summary>Show in Sim info demo.</summary>
     ShowInSimInfoDemo = 1 << 4,
+    /// <summary>Show in CAS demo.</summary>
     ShowInCASDemo = 1 << 5
 }
 
@@ -40,15 +49,25 @@ public enum ParmFlag : byte
 [SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "Legacy name compatibility")]
 public enum AgeGenderFlags : uint
 {
+    /// <summary>No flags set.</summary>
     None = 0,
+    /// <summary>Baby age.</summary>
     Baby = 0x00000001,
+    /// <summary>Toddler age.</summary>
     Toddler = 0x00000002,
+    /// <summary>Child age.</summary>
     Child = 0x00000004,
+    /// <summary>Teen age.</summary>
     Teen = 0x00000008,
+    /// <summary>Young adult age.</summary>
     YoungAdult = 0x00000010,
+    /// <summary>Adult age.</summary>
     Adult = 0x00000020,
+    /// <summary>Elder age.</summary>
     Elder = 0x00000040,
+    /// <summary>Male gender.</summary>
     Male = 0x00001000,
+    /// <summary>Female gender.</summary>
     Female = 0x00002000
 }
 
@@ -58,64 +77,123 @@ public enum AgeGenderFlags : uint
 /// </summary>
 public enum BodyType : uint
 {
+    /// <summary>All body types.</summary>
     All = 0,
+    /// <summary>Hat body type.</summary>
     Hat = 1,
+    /// <summary>Hair body type.</summary>
     Hair = 2,
+    /// <summary>Head body type.</summary>
     Head = 3,
+    /// <summary>Face body type.</summary>
     Face = 4,
+    /// <summary>Body (full body) body type.</summary>
     Body = 5,
+    /// <summary>Top (upper body) body type.</summary>
     Top = 6,
+    /// <summary>Bottom (lower body) body type.</summary>
     Bottom = 7,
+    /// <summary>Shoes body type.</summary>
     Shoes = 8,
+    /// <summary>Accessories body type.</summary>
     Accessories = 9,
+    /// <summary>Earrings body type.</summary>
     Earrings = 0x0A,
+    /// <summary>Glasses body type.</summary>
     Glasses = 0x0B,
+    /// <summary>Necklace body type.</summary>
     Necklace = 0x0C,
+    /// <summary>Gloves body type.</summary>
     Gloves = 0x0D,
+    /// <summary>Left bracelet body type.</summary>
     BraceletLeft = 0x0E,
+    /// <summary>Right bracelet body type.</summary>
     BraceletRight = 0x0F,
+    /// <summary>Left lip ring body type.</summary>
     LipRingLeft = 0x10,
+    /// <summary>Right lip ring body type.</summary>
     LipRingRight = 0x11,
+    /// <summary>Left nose ring body type.</summary>
     NoseRingLeft = 0x12,
+    /// <summary>Right nose ring body type.</summary>
     NoseRingRight = 0x13,
+    /// <summary>Left brow ring body type.</summary>
     BrowRingLeft = 0x14,
+    /// <summary>Right brow ring body type.</summary>
     BrowRingRight = 0x15,
+    /// <summary>Left index finger ring body type.</summary>
     RingIndexLeft = 0x16,
+    /// <summary>Right index finger ring body type.</summary>
     RingIndexRight = 0x17,
+    /// <summary>Left third finger ring body type.</summary>
     RingThirdLeft = 0x18,
+    /// <summary>Right third finger ring body type.</summary>
     RingThirdRight = 0x19,
+    /// <summary>Left middle finger ring body type.</summary>
     RingMidLeft = 0x1A,
+    /// <summary>Right middle finger ring body type.</summary>
     RingMidRight = 0x1B,
+    /// <summary>Facial hair body type.</summary>
     FacialHair = 0x1C,
+    /// <summary>Lipstick body type.</summary>
     Lipstick = 0x1D,
+    /// <summary>Eyeshadow body type.</summary>
     Eyeshadow = 0x1E,
+    /// <summary>Eyeliner body type.</summary>
     Eyeliner = 0x1F,
+    /// <summary>Blush body type.</summary>
     Blush = 0x20,
+    /// <summary>Face paint body type.</summary>
     Facepaint = 0x21,
+    /// <summary>Eyebrows body type.</summary>
     Eyebrows = 0x22,
+    /// <summary>Eye color body type.</summary>
     Eyecolor = 0x23,
+    /// <summary>Socks body type.</summary>
     Socks = 0x24,
+    /// <summary>Mascara body type.</summary>
     Mascara = 0x25,
+    /// <summary>Forehead crease body type.</summary>
     ForeheadCrease = 0x26,
+    /// <summary>Freckles body type.</summary>
     Freckles = 0x27,
+    /// <summary>Left dimple body type.</summary>
     DimpleLeft = 0x28,
+    /// <summary>Right dimple body type.</summary>
     DimpleRight = 0x29,
+    /// <summary>Tights body type.</summary>
     Tights = 0x2A,
+    /// <summary>Left lip mole body type.</summary>
     MoleLeftLip = 0x2B,
+    /// <summary>Right lip mole body type.</summary>
     MoleRightLip = 0x2C,
+    /// <summary>Lower left arm tattoo body type.</summary>
     TattooArmLowerLeft = 0x2D,
+    /// <summary>Upper left arm tattoo body type.</summary>
     TattooArmUpperLeft = 0x2E,
+    /// <summary>Lower right arm tattoo body type.</summary>
     TattooArmLowerRight = 0x2F,
+    /// <summary>Upper right arm tattoo body type.</summary>
     TattooArmUpperRight = 0x30,
+    /// <summary>Left leg tattoo body type.</summary>
     TattooLegLeft = 0x31,
+    /// <summary>Right leg tattoo body type.</summary>
     TattooLegRight = 0x32,
+    /// <summary>Lower back torso tattoo body type.</summary>
     TattooTorsoBackLower = 0x33,
+    /// <summary>Upper back torso tattoo body type.</summary>
     TattooTorsoBackUpper = 0x34,
+    /// <summary>Lower front torso tattoo body type.</summary>
     TattooTorsoFrontLower = 0x35,
+    /// <summary>Upper front torso tattoo body type.</summary>
     TattooTorsoFrontUpper = 0x36,
+    /// <summary>Left cheek mole body type.</summary>
     MoleLeftCheek = 0x37,
+    /// <summary>Right cheek mole body type.</summary>
     MoleRightCheek = 0x38,
+    /// <summary>Mouth crease body type.</summary>
     MouthCrease = 0x39,
+    /// <summary>Skin overlay body type.</summary>
     SkinOverlay = 0x3A
 }
 
@@ -126,8 +204,11 @@ public enum BodyType : uint
 [Flags]
 public enum OccultTypesDisabled : uint
 {
+    /// <summary>No occult types disabled.</summary>
     None = 0,
+    /// <summary>Human occult type.</summary>
     Human = 1,
+    /// <summary>Alien occult type.</summary>
     Alien = 1 << 1
 }
 
@@ -140,64 +221,123 @@ public enum OccultTypesDisabled : uint
 [SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "Legacy name compatibility")]
 public enum ExcludePartFlag : ulong
 {
+    /// <summary>No parts excluded.</summary>
     None = 0,
+    /// <summary>Exclude hat parts.</summary>
     Hat = 1ul << 1,
+    /// <summary>Exclude hair parts.</summary>
     Hair = 1ul << 2,
+    /// <summary>Exclude head parts.</summary>
     Head = 1ul << 3,
+    /// <summary>Exclude face parts.</summary>
     Face = 1ul << 4,
+    /// <summary>Exclude full body parts.</summary>
     FullBody = 1ul << 5,
+    /// <summary>Exclude upper body parts.</summary>
     UpperBody = 1ul << 6,
+    /// <summary>Exclude lower body parts.</summary>
     LowerBody = 1ul << 7,
+    /// <summary>Exclude shoes parts.</summary>
     Shoes = 1ul << 8,
+    /// <summary>Exclude accessories parts.</summary>
     Accessories = 1ul << 9,
+    /// <summary>Exclude earrings parts.</summary>
     Earrings = 1ul << 10,
+    /// <summary>Exclude glasses parts.</summary>
     Glasses = 1ul << 11,
+    /// <summary>Exclude necklace parts.</summary>
     Necklace = 1ul << 12,
+    /// <summary>Exclude gloves parts.</summary>
     Gloves = 1ul << 13,
+    /// <summary>Exclude left wrist parts.</summary>
     WristLeft = 1ul << 14,
+    /// <summary>Exclude right wrist parts.</summary>
     WristRight = 1ul << 15,
+    /// <summary>Exclude left lip ring parts.</summary>
     LipRingLeft = 1ul << 16,
+    /// <summary>Exclude right lip ring parts.</summary>
     LipRingRight = 1ul << 17,
+    /// <summary>Exclude left nose ring parts.</summary>
     NoseRingLeft = 1ul << 18,
+    /// <summary>Exclude right nose ring parts.</summary>
     NoseRingRight = 1ul << 19,
+    /// <summary>Exclude left brow ring parts.</summary>
     BrowRingLeft = 1ul << 20,
+    /// <summary>Exclude right brow ring parts.</summary>
     BrowRingRight = 1ul << 21,
+    /// <summary>Exclude left index finger parts.</summary>
     IndexFingerLeft = 1ul << 22,
+    /// <summary>Exclude right index finger parts.</summary>
     IndexFingerRight = 1ul << 23,
+    /// <summary>Exclude left ring finger parts.</summary>
     RingFingerLeft = 1ul << 24,
+    /// <summary>Exclude right ring finger parts.</summary>
     RingFingerRight = 1ul << 25,
+    /// <summary>Exclude left middle finger parts.</summary>
     MiddleFingerLeft = 1ul << 26,
+    /// <summary>Exclude right middle finger parts.</summary>
     MiddleFingerRight = 1ul << 27,
+    /// <summary>Exclude facial hair parts.</summary>
     FacialHair = 1ul << 28,
+    /// <summary>Exclude lipstick parts.</summary>
     Lipstick = 1ul << 29,
+    /// <summary>Exclude eyeshadow parts.</summary>
     Eyeshadow = 1ul << 30,
+    /// <summary>Exclude eyeliner parts.</summary>
     Eyeliner = 1ul << 31,
+    /// <summary>Exclude blush parts.</summary>
     Blush = 1ul << 32,
+    /// <summary>Exclude face paint parts.</summary>
     Facepaint = 1ul << 33,
+    /// <summary>Exclude eyebrows parts.</summary>
     Eyebrows = 1ul << 34,
+    /// <summary>Exclude eye color parts.</summary>
     Eyecolor = 1ul << 35,
+    /// <summary>Exclude socks parts.</summary>
     Socks = 1ul << 36,
+    /// <summary>Exclude mascara parts.</summary>
     Mascara = 1ul << 37,
+    /// <summary>Exclude forehead crease parts.</summary>
     CreaseForehead = 1ul << 38,
+    /// <summary>Exclude freckles parts.</summary>
     Freckles = 1ul << 39,
+    /// <summary>Exclude left dimple parts.</summary>
     DimpleLeft = 1ul << 40,
+    /// <summary>Exclude right dimple parts.</summary>
     DimpleRight = 1ul << 41,
+    /// <summary>Exclude tights parts.</summary>
     Tights = 1ul << 42,
+    /// <summary>Exclude left lip mole parts.</summary>
     MoleLipLeft = 1ul << 43,
+    /// <summary>Exclude right lip mole parts.</summary>
     MoleLipRight = 1ul << 44,
+    /// <summary>Exclude lower left arm tattoo parts.</summary>
     TattooArmLowerLeft = 1ul << 45,
+    /// <summary>Exclude upper left arm tattoo parts.</summary>
     TattooArmUpperLeft = 1ul << 46,
+    /// <summary>Exclude lower right arm tattoo parts.</summary>
     TattooArmLowerRight = 1ul << 47,
+    /// <summary>Exclude upper right arm tattoo parts.</summary>
     TattooArmUpperRight = 1ul << 48,
+    /// <summary>Exclude left leg tattoo parts.</summary>
     TattooLegLeft = 1ul << 49,
+    /// <summary>Exclude right leg tattoo parts.</summary>
     TattooLegRight = 1ul << 50,
+    /// <summary>Exclude lower back torso tattoo parts.</summary>
     TattooTorsoBackLower = 1ul << 51,
+    /// <summary>Exclude upper back torso tattoo parts.</summary>
     TattooTorsoBackUpper = 1ul << 52,
+    /// <summary>Exclude lower front torso tattoo parts.</summary>
     TattooTorsoFrontLower = 1ul << 53,
+    /// <summary>Exclude upper front torso tattoo parts.</summary>
     TattooTorsoFrontUpper = 1ul << 54,
+    /// <summary>Exclude left cheek mole parts.</summary>
     MoleCheekLeft = 1ul << 55,
+    /// <summary>Exclude right cheek mole parts.</summary>
     MoleCheekRight = 1ul << 56,
+    /// <summary>Exclude mouth crease parts.</summary>
     CreaseMouth = 1ul << 57,
+    /// <summary>Exclude skin overlay parts.</summary>
     SkinOverlay = 1ul << 58
 }
 
@@ -208,21 +348,37 @@ public enum ExcludePartFlag : ulong
 [Flags]
 public enum CASPanelGroupType : uint
 {
+    /// <summary>Unknown value 0.</summary>
     Unknown0 = 0,
+    /// <summary>Unknown value 1.</summary>
     Unknown1 = 1,
+    /// <summary>Head and ears panel group.</summary>
     HeadAndEars = 2,
+    /// <summary>Unknown value 3.</summary>
     Unknown3 = 4,
+    /// <summary>Mouth panel group.</summary>
     Mouth = 8,
+    /// <summary>Nose panel group.</summary>
     Nose = 16,
+    /// <summary>Unknown value 6.</summary>
     Unknown6 = 32,
+    /// <summary>Eyelash panel group.</summary>
     Eyelash = 64,
+    /// <summary>Eyes panel group.</summary>
     Eyes = 128,
+    /// <summary>Unknown value 9.</summary>
     Unknown9 = 256,
+    /// <summary>Unknown value A.</summary>
     UnknownA = 512,
+    /// <summary>Unknown value B.</summary>
     UnknownB = 1024,
+    /// <summary>Unknown value C.</summary>
     UnknownC = 2048,
+    /// <summary>Unknown value D.</summary>
     UnknownD = 4096,
+    /// <summary>Unknown value E.</summary>
     UnknownE = 8192,
+    /// <summary>Unknown value F.</summary>
     UnknownF = 16384
 }
 
@@ -233,21 +389,37 @@ public enum CASPanelGroupType : uint
 [Flags]
 public enum CASPanelSortType : uint
 {
+    /// <summary>Unknown value 0.</summary>
     Unknown0 = 0,
+    /// <summary>Unknown value 1.</summary>
     Unknown1 = 1,
+    /// <summary>Unknown value 2.</summary>
     Unknown2 = 2,
+    /// <summary>Unknown value 3.</summary>
     Unknown3 = 4,
+    /// <summary>Unknown value 4.</summary>
     Unknown4 = 8,
+    /// <summary>Unknown value 5.</summary>
     Unknown5 = 16,
+    /// <summary>Unknown value 6.</summary>
     Unknown6 = 32,
+    /// <summary>Unknown value 7.</summary>
     Unknown7 = 64,
+    /// <summary>Unknown value 8.</summary>
     Unknown8 = 128,
+    /// <summary>Unknown value 9.</summary>
     Unknown9 = 256,
+    /// <summary>Unknown value A.</summary>
     UnknownA = 512,
+    /// <summary>Unknown value B.</summary>
     UnknownB = 1024,
+    /// <summary>Unknown value C.</summary>
     UnknownC = 2048,
+    /// <summary>Unknown value D.</summary>
     UnknownD = 4096,
+    /// <summary>Unknown value E.</summary>
     UnknownE = 8192,
+    /// <summary>Unknown value F.</summary>
     UnknownF = 16384
 }
 
@@ -261,24 +433,44 @@ public enum CASPartRegion : uint
     /// "Base" sub-part by definition does not compete with any other subparts.
     /// </summary>
     Base = 0,
+    /// <summary>Ankle region.</summary>
     Ankle,
+    /// <summary>Calf region.</summary>
     Calf,
+    /// <summary>Knee region.</summary>
     Knee,
+    /// <summary>Left hand region.</summary>
     HandLeft,
+    /// <summary>Left wrist region.</summary>
     WristLeft,
+    /// <summary>Left bicep region.</summary>
     BicepLeft,
+    /// <summary>Low belt region.</summary>
     BeltLow,
+    /// <summary>High belt region.</summary>
     BeltHigh,
+    /// <summary>Hair/hat region A.</summary>
     HairHatA,
+    /// <summary>Hair/hat region B.</summary>
     HairHatB,
+    /// <summary>Hair/hat region C.</summary>
     HairHatC,
+    /// <summary>Hair/hat region D.</summary>
     HairHatD,
+    /// <summary>Neck region.</summary>
     Neck,
+    /// <summary>Chest region.</summary>
     Chest,
+    /// <summary>Stomach region.</summary>
     Stomach,
+    /// <summary>Right hand region.</summary>
     HandRight,
+    /// <summary>Right wrist region.</summary>
     WristRight,
+    /// <summary>Right bicep region.</summary>
     BicepRight,
+    /// <summary>Necklace shadow region.</summary>
     NecklaceShadow,
+    /// <summary>Maximum region value.</summary>
     Max
 }

--- a/src/TS4Tools.Wrappers/CasPartResource/SimOutfitResource.cs
+++ b/src/TS4Tools.Wrappers/CasPartResource/SimOutfitResource.cs
@@ -24,15 +24,43 @@ public sealed class SimOutfitResource : TypedResource
     public uint Version { get; set; }
 
     /// <summary>
-    /// Unknown float values 1-8.
+    /// Unknown float value 1.
     /// </summary>
     public float Unknown1 { get; set; }
+
+    /// <summary>
+    /// Unknown float value 2.
+    /// </summary>
     public float Unknown2 { get; set; }
+
+    /// <summary>
+    /// Unknown float value 3.
+    /// </summary>
     public float Unknown3 { get; set; }
+
+    /// <summary>
+    /// Unknown float value 4.
+    /// </summary>
     public float Unknown4 { get; set; }
+
+    /// <summary>
+    /// Unknown float value 5.
+    /// </summary>
     public float Unknown5 { get; set; }
+
+    /// <summary>
+    /// Unknown float value 6.
+    /// </summary>
     public float Unknown6 { get; set; }
+
+    /// <summary>
+    /// Unknown float value 7.
+    /// </summary>
     public float Unknown7 { get; set; }
+
+    /// <summary>
+    /// Unknown float value 8.
+    /// </summary>
     public float Unknown8 { get; set; }
 
     /// <summary>

--- a/src/TS4Tools.Wrappers/CatalogResource/Common/CatalogCommon.cs
+++ b/src/TS4Tools.Wrappers/CatalogResource/Common/CatalogCommon.cs
@@ -8,7 +8,14 @@ namespace TS4Tools.Wrappers.CatalogResource;
 [Flags]
 public enum PackDisplayOption : byte
 {
+    /// <summary>
+    /// No special display options.
+    /// </summary>
     None = 0,
+
+    /// <summary>
+    /// Hide the pack icon in the catalog UI.
+    /// </summary>
     HidePackIcon = 1
 }
 

--- a/src/TS4Tools.Wrappers/CatalogResource/CwalResource.cs
+++ b/src/TS4Tools.Wrappers/CatalogResource/CwalResource.cs
@@ -124,8 +124,19 @@ public sealed class CwalResource : SimpleCatalogResource
 /// </summary>
 public enum MainWallHeight : byte
 {
+    /// <summary>
+    /// Short wall height.
+    /// </summary>
     ShortWall = 0x03,
+
+    /// <summary>
+    /// Medium wall height.
+    /// </summary>
     MediumWall = 0x04,
+
+    /// <summary>
+    /// Tall wall height.
+    /// </summary>
     TallWall = 0x05,
 }
 
@@ -135,8 +146,19 @@ public enum MainWallHeight : byte
 /// </summary>
 public enum CornerWallHeight : byte
 {
+    /// <summary>
+    /// Short corner wall height.
+    /// </summary>
     ShortWall = 0xC3,
+
+    /// <summary>
+    /// Medium corner wall height.
+    /// </summary>
     MediumWall = 0xC4,
+
+    /// <summary>
+    /// Tall corner wall height.
+    /// </summary>
     TallWall = 0xC5,
 }
 

--- a/src/TS4Tools.Wrappers/ImageResource/DxtDecoder.cs
+++ b/src/TS4Tools.Wrappers/ImageResource/DxtDecoder.cs
@@ -21,9 +21,13 @@ public static class DxtDecoder
     private const int DdsHeaderSize = 128;
 
     /// <summary>
-    /// FourCC values for DXT formats.
+    /// FourCC value for DXT1 format (BC1 compression).
     /// </summary>
     public const uint FourCcDxt1 = 0x31545844; // "DXT1"
+
+    /// <summary>
+    /// FourCC value for DXT5 format (BC3 compression).
+    /// </summary>
     public const uint FourCcDxt5 = 0x35545844; // "DXT5"
 
     /// <summary>

--- a/src/TS4Tools.Wrappers/JazzChunks/Blocks/JazzPlayAnimationNodeBlock.cs
+++ b/src/TS4Tools.Wrappers/JazzChunks/Blocks/JazzPlayAnimationNodeBlock.cs
@@ -85,12 +85,22 @@ public sealed class JazzPlayAnimationNodeBlock : RcolBlock
     /// <summary>Timing priority.</summary>
     public JazzAnimationPriority TimingPriority { get; set; } = JazzAnimationPriority.Unset;
 
-    /// <summary>Unknown fields 13-18.</summary>
+    /// <summary>Unknown field 13.</summary>
     public uint Unknown13 { get; set; }
+
+    /// <summary>Unknown field 14.</summary>
     public uint Unknown14 { get; set; }
+
+    /// <summary>Unknown field 15.</summary>
     public uint Unknown15 { get; set; }
+
+    /// <summary>Unknown field 16.</summary>
     public uint Unknown16 { get; set; }
+
+    /// <summary>Unknown field 17.</summary>
     public uint Unknown17 { get; set; }
+
+    /// <summary>Unknown field 18.</summary>
     public uint Unknown18 { get; set; }
 
     /// <summary>Decision graph chunk indexes.</summary>

--- a/src/TS4Tools.Wrappers/JazzChunks/Blocks/JazzStopAnimationNodeBlock.cs
+++ b/src/TS4Tools.Wrappers/JazzChunks/Blocks/JazzStopAnimationNodeBlock.cs
@@ -55,12 +55,22 @@ public sealed class JazzStopAnimationNodeBlock : RcolBlock
     /// <summary>Timing priority.</summary>
     public JazzAnimationPriority TimingPriority { get; set; } = JazzAnimationPriority.Unset;
 
-    /// <summary>Unknown fields 6-11.</summary>
+    /// <summary>Unknown field 6.</summary>
     public uint Unknown6 { get; set; }
+
+    /// <summary>Unknown field 7.</summary>
     public uint Unknown7 { get; set; }
+
+    /// <summary>Unknown field 8.</summary>
     public uint Unknown8 { get; set; }
+
+    /// <summary>Unknown field 9.</summary>
     public uint Unknown9 { get; set; }
+
+    /// <summary>Unknown field 10.</summary>
     public uint Unknown10 { get; set; }
+
+    /// <summary>Unknown field 11.</summary>
     public uint Unknown11 { get; set; }
 
     /// <summary>Decision graph chunk indexes.</summary>

--- a/src/TS4Tools.Wrappers/JazzChunks/JazzCommon.cs
+++ b/src/TS4Tools.Wrappers/JazzChunks/JazzCommon.cs
@@ -182,6 +182,7 @@ public sealed class JazzAnimation
     /// <summary>Second actor hash.</summary>
     public uint Actor2Hash { get; set; }
 
+    /// <summary>Parses an animation entry from binary data.</summary>
     public static JazzAnimation Parse(ReadOnlySpan<byte> data, ref int offset)
     {
         var anim = new JazzAnimation
@@ -196,6 +197,7 @@ public sealed class JazzAnimation
         return anim;
     }
 
+    /// <summary>Writes the animation entry to binary format.</summary>
     public void Write(BinaryWriter writer)
     {
         writer.Write(NameHash);
@@ -210,11 +212,19 @@ public sealed class JazzAnimation
 /// </summary>
 public sealed class JazzActorSlot
 {
+    /// <summary>Chain identifier.</summary>
     public uint ChainId { get; set; }
+
+    /// <summary>Slot identifier.</summary>
     public uint SlotId { get; set; }
+
+    /// <summary>Actor name hash.</summary>
     public uint ActorNameHash { get; set; }
+
+    /// <summary>Slot name hash.</summary>
     public uint SlotNameHash { get; set; }
 
+    /// <summary>Parses an actor slot from binary data.</summary>
     public static JazzActorSlot Parse(ReadOnlySpan<byte> data, ref int offset)
     {
         var slot = new JazzActorSlot
@@ -231,6 +241,7 @@ public sealed class JazzActorSlot
         return slot;
     }
 
+    /// <summary>Writes the actor slot to binary format.</summary>
     public void Write(BinaryWriter writer)
     {
         writer.Write(ChainId);
@@ -246,9 +257,13 @@ public sealed class JazzActorSlot
 /// </summary>
 public sealed class JazzActorSuffix
 {
+    /// <summary>Actor name hash.</summary>
     public uint ActorNameHash { get; set; }
+
+    /// <summary>Suffix hash.</summary>
     public uint SuffixHash { get; set; }
 
+    /// <summary>Parses an actor suffix from binary data.</summary>
     public static JazzActorSuffix Parse(ReadOnlySpan<byte> data, ref int offset)
     {
         var suffix = new JazzActorSuffix
@@ -261,6 +276,7 @@ public sealed class JazzActorSuffix
         return suffix;
     }
 
+    /// <summary>Writes the actor suffix to binary format.</summary>
     public void Write(BinaryWriter writer)
     {
         writer.Write(ActorNameHash);
@@ -274,9 +290,13 @@ public sealed class JazzActorSuffix
 /// </summary>
 public sealed class JazzOutcome
 {
+    /// <summary>Outcome weight for random selection.</summary>
     public float Weight { get; set; }
+
+    /// <summary>Decision graph chunk indexes for this outcome.</summary>
     public List<uint> DecisionGraphIndexes { get; set; } = [];
 
+    /// <summary>Parses an outcome entry from binary data.</summary>
     public static JazzOutcome Parse(ReadOnlySpan<byte> data, ref int offset)
     {
         var outcome = new JazzOutcome
@@ -288,6 +308,7 @@ public sealed class JazzOutcome
         return outcome;
     }
 
+    /// <summary>Writes the outcome entry to binary format.</summary>
     public void Write(BinaryWriter writer)
     {
         writer.Write(Weight);
@@ -301,9 +322,13 @@ public sealed class JazzOutcome
 /// </summary>
 public sealed class JazzParameterMatch
 {
+    /// <summary>Test value for parameter matching.</summary>
     public uint TestValue { get; set; }
+
+    /// <summary>Decision graph chunk indexes for this match.</summary>
     public List<uint> DecisionGraphIndexes { get; set; } = [];
 
+    /// <summary>Parses a parameter match from binary data.</summary>
     public static JazzParameterMatch Parse(ReadOnlySpan<byte> data, ref int offset)
     {
         var match = new JazzParameterMatch
@@ -315,6 +340,7 @@ public sealed class JazzParameterMatch
         return match;
     }
 
+    /// <summary>Writes the parameter match to binary format.</summary>
     public void Write(BinaryWriter writer)
     {
         writer.Write(TestValue);
@@ -328,9 +354,13 @@ public sealed class JazzParameterMatch
 /// </summary>
 public sealed class JazzDestinationMatch
 {
+    /// <summary>State index for destination matching.</summary>
     public uint StateIndex { get; set; }
+
+    /// <summary>Decision graph chunk indexes for this match.</summary>
     public List<uint> DecisionGraphIndexes { get; set; } = [];
 
+    /// <summary>Parses a destination match from binary data.</summary>
     public static JazzDestinationMatch Parse(ReadOnlySpan<byte> data, ref int offset)
     {
         var match = new JazzDestinationMatch
@@ -342,6 +372,7 @@ public sealed class JazzDestinationMatch
         return match;
     }
 
+    /// <summary>Writes the destination match to binary format.</summary>
     public void Write(BinaryWriter writer)
     {
         writer.Write(StateIndex);

--- a/src/TS4Tools.Wrappers/JazzChunks/JazzConstants.cs
+++ b/src/TS4Tools.Wrappers/JazzChunks/JazzConstants.cs
@@ -14,22 +14,50 @@ namespace TS4Tools.Wrappers.JazzChunks;
 public static class JazzConstants
 {
     // Markers
+    /// <summary>DEADBEEF marker used in Jazz chunks.</summary>
     public const uint DeadBeef = 0xDEADBEEF;
+
+    /// <summary>CloseDGN marker ("/DGN") used in Jazz chunks.</summary>
     public const uint CloseDgn = 0x4E47442F; // "/DGN" in little-endian
 
     // Jazz chunk type IDs
+    /// <summary>State Machine chunk type (S_SM).</summary>
     public const uint StateMachine = 0x02D5DF13;           // S_SM
+
+    /// <summary>State chunk type (S_St).</summary>
     public const uint State = 0x02EEDAFE;                   // S_St (note: legacy code shows S_St for State, but returns 0x02EEDAFE)
+
+    /// <summary>Decision Graph chunk type (S_DG).</summary>
     public const uint DecisionGraph = 0x02EEDB18;           // S_DG
+
+    /// <summary>Actor Definition chunk type (S_AD).</summary>
     public const uint ActorDefinition = 0x02EEDB2F;         // S_AD
+
+    /// <summary>Parameter Definition chunk type (S_PD).</summary>
     public const uint ParameterDefinition = 0x02EEDB46;     // S_PD
+
+    /// <summary>Play Animation Node chunk type (Play).</summary>
     public const uint PlayAnimationNode = 0x02EEDB5F;       // Play
+
+    /// <summary>Random Node chunk type (Rand).</summary>
     public const uint RandomNode = 0x02EEDB70;              // Rand
+
+    /// <summary>Select On Parameter Node chunk type (SoPn).</summary>
     public const uint SelectOnParameterNode = 0x02EEDB92;   // SoPn
+
+    /// <summary>Select On Destination Node chunk type (DG00).</summary>
     public const uint SelectOnDestinationNode = 0x02EEDBA5; // DG00
+
+    /// <summary>Next State Node chunk type (SNSN).</summary>
     public const uint NextStateNode = 0x02EEEBDC;           // SNSN
+
+    /// <summary>Create Prop Node chunk type (Prop).</summary>
     public const uint CreatePropNode = 0x02EEEBDD;          // Prop
+
+    /// <summary>Actor Operation Node chunk type (AcOp).</summary>
     public const uint ActorOperationNode = 0x02EEEBDE;      // AcOp
+
+    /// <summary>Stop Animation Node chunk type (Stop).</summary>
     public const uint StopAnimationNode = 0x0344D438;       // Stop
 
     /// <summary>
@@ -59,22 +87,55 @@ public static class JazzConstants
 /// </summary>
 public enum JazzAnimationPriority : uint
 {
+    /// <summary>Default priority (-2).</summary>
     Default = 0xFFFFFFFE,    // -2
+
+    /// <summary>Broadcast priority (-1).</summary>
     Broadcast = 0xFFFFFFFF,  // -1
+
+    /// <summary>Unset priority (0).</summary>
     Unset = 0,
+
+    /// <summary>Low priority (6000).</summary>
     Low = 6000,
+
+    /// <summary>Low plus priority (8000).</summary>
     LowPlus = 8000,
+
+    /// <summary>Normal priority (10000).</summary>
     Normal = 10000,
+
+    /// <summary>Normal plus priority (15000).</summary>
     NormalPlus = 15000,
+
+    /// <summary>Facial idle priority (17500).</summary>
     FacialIdle = 17500,
+
+    /// <summary>High priority (20000).</summary>
     High = 20000,
+
+    /// <summary>High plus priority (25000).</summary>
     HighPlus = 25000,
+
+    /// <summary>Carry right priority (30000).</summary>
     CarryRight = 30000,
+
+    /// <summary>Carry right plus priority (35000).</summary>
     CarryRightPlus = 35000,
+
+    /// <summary>Carry left priority (40000).</summary>
     CarryLeft = 40000,
+
+    /// <summary>Carry left plus priority (45000).</summary>
     CarryLeftPlus = 45000,
+
+    /// <summary>Ultra priority (50000).</summary>
     Ultra = 50000,
+
+    /// <summary>Ultra plus priority (55000).</summary>
     UltraPlus = 55000,
+
+    /// <summary>Look at priority (60000).</summary>
     LookAt = 60000,
 }
 
@@ -84,12 +145,25 @@ public enum JazzAnimationPriority : uint
 /// </summary>
 public enum JazzAwarenessLevel : uint
 {
+    /// <summary>Thought bubble overlay.</summary>
     ThoughtBubble = 0,
+
+    /// <summary>Face overlay.</summary>
     OverlayFace = 1,
+
+    /// <summary>Head overlay.</summary>
     OverlayHead = 2,
+
+    /// <summary>Both arms overlay.</summary>
     OverlayBothArms = 3,
+
+    /// <summary>Upper body overlay.</summary>
     OverlayUpperbody = 4,
+
+    /// <summary>No overlay.</summary>
     OverlayNone = 5,
+
+    /// <summary>Unset awareness level.</summary>
     Unset = 6,
 }
 
@@ -100,10 +174,19 @@ public enum JazzAwarenessLevel : uint
 [Flags]
 public enum JazzStateMachineFlags : uint
 {
+    /// <summary>Default flag.</summary>
     Default = 0x01,
+
+    /// <summary>Unilateral actor flag (alias for Default).</summary>
     UnilateralActor = 0x01,  // Alias for Default in legacy
+
+    /// <summary>Pin all resources flag.</summary>
     PinAllResources = 0x02,
+
+    /// <summary>Blend motion accumulation flag.</summary>
     BlendMotionAccumulation = 0x04,
+
+    /// <summary>Hold all poses flag.</summary>
     HoldAllPoses = 0x08,
 }
 
@@ -114,15 +197,34 @@ public enum JazzStateMachineFlags : uint
 [Flags]
 public enum JazzStateFlags : uint
 {
+    /// <summary>No flags.</summary>
     None = 0x0000,
+
+    /// <summary>Public state flag.</summary>
     Public = 0x0001,
+
+    /// <summary>Entry state flag.</summary>
     Entry = 0x0002,
+
+    /// <summary>Exit state flag.</summary>
     Exit = 0x0004,
+
+    /// <summary>Loop state flag.</summary>
     Loop = 0x0008,
+
+    /// <summary>One-shot state flag.</summary>
     OneShot = 0x0010,
+
+    /// <summary>One-shot hold state flag.</summary>
     OneShotHold = 0x0020,
+
+    /// <summary>Synchronized state flag.</summary>
     Synchronized = 0x0040,
+
+    /// <summary>Join state flag.</summary>
     Join = 0x0080,
+
+    /// <summary>Explicit state flag.</summary>
     Explicit = 0x0100,
 }
 
@@ -133,28 +235,73 @@ public enum JazzStateFlags : uint
 [Flags]
 public enum JazzAnimationNodeFlags : uint
 {
+    /// <summary>Normal timing flag.</summary>
     TimingNormal = 0x00,
+
+    /// <summary>Default flag.</summary>
     Default = 0x01,
+
+    /// <summary>At end flag (alias for Default).</summary>
     AtEnd = 0x01,              // Alias for Default in legacy
+
+    /// <summary>Loop as needed flag.</summary>
     LoopAsNeeded = 0x02,
+
+    /// <summary>Override priority flag.</summary>
     OverridePriority = 0x04,
+
+    /// <summary>Mirror animation flag.</summary>
     Mirror = 0x08,
+
+    /// <summary>Override mirror flag.</summary>
     OverrideMirror = 0x10,
+
+    /// <summary>Override timing 0 flag.</summary>
     OverrideTiming0 = 0x20,
+
+    /// <summary>Override timing 1 flag.</summary>
     OverrideTiming1 = 0x40,
+
+    /// <summary>Timing master flag (alias for OverrideTiming0).</summary>
     TimingMaster = 0x20,       // Alias for OverrideTiming0 in legacy
+
+    /// <summary>Timing slave flag (alias for OverrideTiming1).</summary>
     TimingSlave = 0x40,        // Alias for OverrideTiming1 in legacy
+
+    /// <summary>Timing ignored flag.</summary>
     TimingIgnored = 0x60,
+
+    /// <summary>Timing mask flag (alias for TimingIgnored).</summary>
     TimingMask = 0x60,         // Alias for TimingIgnored in legacy
+
+    /// <summary>Interruptible animation flag.</summary>
     Interruptible = 0x80,
+
+    /// <summary>Force blend flag.</summary>
     ForceBlend = 0x100,
+
+    /// <summary>Use timing priority flag.</summary>
     UseTimingPriority = 0x200,
+
+    /// <summary>Use timing priority as clock master flag.</summary>
     UseTimingPriorityAsClockMaster = 0x400,
+
+    /// <summary>Base clip is social flag.</summary>
     BaseClipIsSocial = 0x800,
+
+    /// <summary>Additive clip is social flag.</summary>
     AdditiveClipIsSocial = 0x1000,
+
+    /// <summary>Base clip is object only flag.</summary>
     BaseClipIsObjectOnly = 0x2000,
+
+    /// <summary>Additive clip is object only flag.</summary>
     AdditiveClipIsObjectOnly = 0x4000,
+
+    /// <summary>Hold pose flag.</summary>
     HoldPose = 0x8000,
+
+    /// <summary>Blend motion accumulation flag.</summary>
     BlendMotionAccumulation = 0x10000,
 }
 
@@ -165,7 +312,10 @@ public enum JazzAnimationNodeFlags : uint
 [Flags]
 public enum JazzRandomNodeFlags : uint
 {
+    /// <summary>No flags.</summary>
     None = 0x00,
+
+    /// <summary>Avoid repeats flag.</summary>
     AvoidRepeats = 0x01,
 }
 
@@ -175,7 +325,10 @@ public enum JazzRandomNodeFlags : uint
 /// </summary>
 public enum JazzActorOperation : uint
 {
+    /// <summary>No operation.</summary>
     None = 0,
+
+    /// <summary>Set mirror operation.</summary>
     SetMirror = 1,
 }
 

--- a/src/TS4Tools.Wrappers/MeshChunks/Blocks/BondBlock.cs
+++ b/src/TS4Tools.Wrappers/MeshChunks/Blocks/BondBlock.cs
@@ -69,6 +69,7 @@ public sealed class SlotAdjustment : IEquatable<SlotAdjustment>
     /// <summary>Size in bytes when serialized.</summary>
     public const int Size = 4 + MeshVector3.Size + MeshVector3.Size + MeshVector4.Size; // 4 + 12 + 12 + 16 = 44
 
+    /// <inheritdoc/>
     public bool Equals(SlotAdjustment? other)
     {
         if (other is null) return false;
@@ -78,8 +79,11 @@ public sealed class SlotAdjustment : IEquatable<SlotAdjustment>
             && Quaternion == other.Quaternion;
     }
 
+    /// <inheritdoc/>
     public override bool Equals(object? obj) => obj is SlotAdjustment other && Equals(other);
+    /// <inheritdoc/>
     public override int GetHashCode() => HashCode.Combine(SlotNameHash, Offset, Scale, Quaternion);
+    /// <inheritdoc/>
     public override string ToString() => $"SlotAdjustment 0x{SlotNameHash:X8}";
 }
 

--- a/src/TS4Tools.Wrappers/MeshChunks/Blocks/FtptBlock.cs
+++ b/src/TS4Tools.Wrappers/MeshChunks/Blocks/FtptBlock.cs
@@ -280,9 +280,14 @@ public sealed class FtptBlock : RcolBlock
 /// </summary>
 public readonly struct FtptPolygonHeightOverride
 {
+    /// <summary>FNV32 hash of the polygon name.</summary>
     public uint NameHash { get; }
+    /// <summary>Height override value.</summary>
     public float Height { get; }
 
+    /// <summary>
+    /// Creates a polygon height override.
+    /// </summary>
     public FtptPolygonHeightOverride(uint nameHash, float height)
     {
         NameHash = nameHash;
@@ -296,9 +301,14 @@ public readonly struct FtptPolygonHeightOverride
 /// </summary>
 public readonly struct FtptPolygonPoint
 {
+    /// <summary>X coordinate.</summary>
     public float X { get; }
+    /// <summary>Z coordinate.</summary>
     public float Z { get; }
 
+    /// <summary>
+    /// Creates a polygon point.
+    /// </summary>
     public FtptPolygonPoint(float x, float z)
     {
         X = x;
@@ -312,16 +322,28 @@ public readonly struct FtptPolygonPoint
 /// </summary>
 public sealed class FtptArea
 {
+    /// <summary>FNV32 hash of the area name.</summary>
     public uint NameHash { get; }
+    /// <summary>Area priority value.</summary>
     public byte Priority { get; }
+    /// <summary>Type of area.</summary>
     public uint AreaType { get; }
+    /// <summary>List of polygon points defining the area boundary.</summary>
     public IReadOnlyList<FtptPolygonPoint> Points { get; }
+    /// <summary>List of surface type flags.</summary>
     public IReadOnlyList<uint> SurfaceTypes { get; }
+    /// <summary>Minimum X coordinate of bounding box.</summary>
     public float MinX { get; }
+    /// <summary>Minimum Z coordinate of bounding box.</summary>
     public float MinZ { get; }
+    /// <summary>Maximum X coordinate of bounding box.</summary>
     public float MaxX { get; }
+    /// <summary>Maximum Z coordinate of bounding box.</summary>
     public float MaxZ { get; }
 
+    /// <summary>
+    /// Creates a footprint/slot area.
+    /// </summary>
     public FtptArea(uint nameHash, byte priority, uint areaType,
         IReadOnlyList<FtptPolygonPoint> points, IReadOnlyList<uint> surfaceTypes,
         float minX, float minZ, float maxX, float maxZ)

--- a/src/TS4Tools.Wrappers/MeshChunks/Blocks/IbufBlock.cs
+++ b/src/TS4Tools.Wrappers/MeshChunks/Blocks/IbufBlock.cs
@@ -198,6 +198,12 @@ public sealed class Ibuf2Block : IbufBlock
     /// <inheritdoc/>
     public override uint ResourceType => TypeId;
 
+    /// <summary>
+    /// Creates an empty IBUF2 block.
+    /// </summary>
     public Ibuf2Block() : base() { }
+    /// <summary>
+    /// Creates an IBUF2 block from raw data.
+    /// </summary>
     public Ibuf2Block(ReadOnlySpan<byte> data) : base(data) { }
 }

--- a/src/TS4Tools.Wrappers/MeshChunks/Blocks/LiteBlock.cs
+++ b/src/TS4Tools.Wrappers/MeshChunks/Blocks/LiteBlock.cs
@@ -7,17 +7,29 @@ namespace TS4Tools.Wrappers.MeshChunks;
 /// </summary>
 public enum LightSourceType : uint
 {
+    /// <summary>Unknown light type.</summary>
     Unknown = 0x00,
+    /// <summary>Ambient light.</summary>
     Ambient = 0x01,
+    /// <summary>Directional light.</summary>
     Directional = 0x02,
+    /// <summary>Point light.</summary>
     Point = 0x03,
+    /// <summary>Spot light.</summary>
     Spot = 0x04,
+    /// <summary>Lamp shade light.</summary>
     LampShade = 0x05,
+    /// <summary>Tube light.</summary>
     TubeLight = 0x06,
+    /// <summary>Square window light.</summary>
     SquareWindow = 0x07,
+    /// <summary>Circular window light.</summary>
     CircularWindow = 0x08,
+    /// <summary>Square area light.</summary>
     SquareAreaLight = 0x09,
+    /// <summary>Disc area light.</summary>
     DiscAreaLight = 0x0A,
+    /// <summary>World light.</summary>
     WorldLight = 0x0B,
 }
 
@@ -27,7 +39,9 @@ public enum LightSourceType : uint
 /// </summary>
 public enum OccluderType : uint
 {
+    /// <summary>Disc-shaped occluder.</summary>
     Disc = 0x00,
+    /// <summary>Rectangle-shaped occluder.</summary>
     Rectangle = 0x01,
 }
 
@@ -269,6 +283,9 @@ public sealed class LiteLightSource
     /// <summary>Type-specific light data (24 floats).</summary>
     public float[] LightData { get; }
 
+    /// <summary>
+    /// Creates a light source.
+    /// </summary>
     public LiteLightSource(LightSourceType lightType, MeshVector3 transform, MeshVector3 color,
         float intensity, float[] lightData)
     {
@@ -307,6 +324,9 @@ public sealed class LiteOccluder
     /// <summary>Pair offset distance.</summary>
     public float PairOffset { get; }
 
+    /// <summary>
+    /// Creates a shadow occluder.
+    /// </summary>
     public LiteOccluder(OccluderType occluderType, MeshVector3 origin, MeshVector3 normal,
         MeshVector3 xAxis, MeshVector3 yAxis, float pairOffset)
     {

--- a/src/TS4Tools.Wrappers/MeshChunks/Blocks/MatdBlock.cs
+++ b/src/TS4Tools.Wrappers/MeshChunks/Blocks/MatdBlock.cs
@@ -7,52 +7,99 @@ namespace TS4Tools.Wrappers.MeshChunks;
 /// </summary>
 public enum MatdShaderType : uint
 {
+    /// <summary>No shader.</summary>
     None = 0x00000000,
+    /// <summary>Subtractive blending shader.</summary>
     Subtractive = 0x0B272CC5,
+    /// <summary>Instanced rendering shader.</summary>
     Instanced = 0x0CB82EB8,
+    /// <summary>Full bright shader.</summary>
     FullBright = 0x14FA335E,
+    /// <summary>Preview walls and floors shader.</summary>
     PreviewWallsAndFloors = 0x213D6300,
+    /// <summary>Shadow map shader.</summary>
     ShadowMap = 0x21FE207D,
+    /// <summary>Glass for rabbit holes shader.</summary>
     GlassForRabbitHoles = 0x265FFAA1,
+    /// <summary>Impostor water shader.</summary>
     ImpostorWater = 0x277CF8EB,
+    /// <summary>Rug shader.</summary>
     Rug = 0x2A72B9A1,
+    /// <summary>Trampoline shader.</summary>
     Trampoline = 0x3939E094,
+    /// <summary>Foliage shader.</summary>
     Foliage = 0x4549E22E,
+    /// <summary>Particle animation shader.</summary>
     ParticleAnim = 0x460E93F4,
+    /// <summary>Solid Phong shader.</summary>
     SolidPhong = 0x47C6638C,
+    /// <summary>Glass for objects shader.</summary>
     GlassForObjects = 0x492ECA7C,
+    /// <summary>Stairs shader.</summary>
     Stairs = 0x4CE2F497,
+    /// <summary>Outdoor prop shader.</summary>
     OutdoorProp = 0x4D26BEC0,
+    /// <summary>Glass for fences shader.</summary>
     GlassForFences = 0x52986C62,
+    /// <summary>Sim skin shader.</summary>
     SimSkin = 0x548394B9,
+    /// <summary>Additive blending shader.</summary>
     Additive = 0x5AF16731,
+    /// <summary>Sim glass shader.</summary>
     SimGlass = 0x5EDA9CDE,
+    /// <summary>Fence shader.</summary>
     Fence = 0x67107FE8,
+    /// <summary>Lot imposter shader.</summary>
     LotImposter = 0x68601DE3,
+    /// <summary>Blueprint shader.</summary>
     Blueprint = 0x6864A45E,
+    /// <summary>Basin water shader.</summary>
     BasinWater = 0x6AAD2AD5,
+    /// <summary>Standing water shader.</summary>
     StandingWater = 0x70FDE012,
+    /// <summary>Building window shader.</summary>
     BuildingWindow = 0x7B036C01,
+    /// <summary>Roof shader.</summary>
     Roof = 0x7BD05F63,
+    /// <summary>Glass for portals shader.</summary>
     GlassForPortals = 0x81DD204D,
+    /// <summary>Glass for objects translucent shader.</summary>
     GlassForObjectsTranslucent = 0x849CF021,
+    /// <summary>Sim hair shader.</summary>
     SimHair = 0x84FD7152,
+    /// <summary>Landmark shader.</summary>
     Landmark = 0x8A60B969,
+    /// <summary>Rabbit hole high detail shader.</summary>
     RabbitHoleHighDetail = 0x8D346BBC,
+    /// <summary>CAS room shader.</summary>
     CASRoom = 0x94B9A835,
+    /// <summary>Sim eyelashes shader.</summary>
     SimEyelashes = 0x9D9DA161,
+    /// <summary>Gemstones shader.</summary>
     Gemstones = 0xA063C1D0,
+    /// <summary>Counters shader.</summary>
     Counters = 0xA4172F62,
+    /// <summary>Flat mirror shader.</summary>
     FlatMirror = 0xA68D9E29,
+    /// <summary>Painting shader.</summary>
     Painting = 0xAA495821,
+    /// <summary>Rabbit hole medium detail shader.</summary>
     RabbitHoleMediumDetail = 0xAEDE7105,
+    /// <summary>Phong shader.</summary>
     Phong = 0xB9105A6D,
+    /// <summary>Floors shader.</summary>
     Floors = 0xBC84D000,
+    /// <summary>Drop shadow shader.</summary>
     DropShadow = 0xC09C7582,
+    /// <summary>Sim eyes shader.</summary>
     SimEyes = 0xCF8A70B4,
+    /// <summary>Plumbob shader.</summary>
     Plumbob = 0xDEF16564,
+    /// <summary>Sculpture ice shader.</summary>
     SculptureIce = 0xE5D98507,
+    /// <summary>Phong alpha shader.</summary>
     PhongAlpha = 0xFC5FC212,
+    /// <summary>Particle jet shader.</summary>
     ParticleJet = 0xFF5E6908,
 }
 

--- a/src/TS4Tools.Wrappers/MeshChunks/Blocks/MtstBlock.cs
+++ b/src/TS4Tools.Wrappers/MeshChunks/Blocks/MtstBlock.cs
@@ -7,11 +7,17 @@ namespace TS4Tools.Wrappers.MeshChunks;
 /// </summary>
 public enum MaterialState : uint
 {
+    /// <summary>Default material state.</summary>
     Default = 0x2EA8FB98,
+    /// <summary>Dirty material state.</summary>
     Dirty = 0xEEAB4327,
+    /// <summary>Very dirty material state.</summary>
     VeryDirty = 0x2E5DF9BB,
+    /// <summary>Burnt material state.</summary>
     Burnt = 0xC3867C32,
+    /// <summary>Clogged material state.</summary>
     Clogged = 0x257FB026,
+    /// <summary>Car lights off state.</summary>
     CarLightsOff = 0xE4AF52C1,
 }
 
@@ -203,20 +209,29 @@ public readonly struct MtstEntry200 : IEquatable<MtstEntry200>
     /// <summary>Material state (Default, Dirty, etc.).</summary>
     public MaterialState MaterialState { get; }
 
+    /// <summary>
+    /// Creates a new MTST entry.
+    /// </summary>
     public MtstEntry200(RcolChunkReference matdIndex, MaterialState materialState)
     {
         MatdIndex = matdIndex;
         MaterialState = materialState;
     }
 
+    /// <inheritdoc/>
     public bool Equals(MtstEntry200 other) =>
         MatdIndex == other.MatdIndex && MaterialState == other.MaterialState;
 
+    /// <inheritdoc/>
     public override bool Equals(object? obj) => obj is MtstEntry200 other && Equals(other);
+    /// <inheritdoc/>
     public override int GetHashCode() => HashCode.Combine(MatdIndex, MaterialState);
+    /// <summary>Equality operator.</summary>
     public static bool operator ==(MtstEntry200 left, MtstEntry200 right) => left.Equals(right);
+    /// <summary>Inequality operator.</summary>
     public static bool operator !=(MtstEntry200 left, MtstEntry200 right) => !left.Equals(right);
 
+    /// <inheritdoc/>
     public override string ToString() => $"Index={MatdIndex}, State={MaterialState}";
 }
 
@@ -239,6 +254,9 @@ public readonly struct MtstEntry300 : IEquatable<MtstEntry300>
     /// <summary>Material variant identifier.</summary>
     public uint MaterialVariant { get; }
 
+    /// <summary>
+    /// Creates a new MTST entry with variant.
+    /// </summary>
     public MtstEntry300(RcolChunkReference matdIndex, MaterialState materialState, uint materialVariant)
     {
         MatdIndex = matdIndex;
@@ -246,16 +264,22 @@ public readonly struct MtstEntry300 : IEquatable<MtstEntry300>
         MaterialVariant = materialVariant;
     }
 
+    /// <inheritdoc/>
     public bool Equals(MtstEntry300 other) =>
         MatdIndex == other.MatdIndex &&
         MaterialState == other.MaterialState &&
         MaterialVariant == other.MaterialVariant;
 
+    /// <inheritdoc/>
     public override bool Equals(object? obj) => obj is MtstEntry300 other && Equals(other);
+    /// <inheritdoc/>
     public override int GetHashCode() => HashCode.Combine(MatdIndex, MaterialState, MaterialVariant);
+    /// <summary>Equality operator.</summary>
     public static bool operator ==(MtstEntry300 left, MtstEntry300 right) => left.Equals(right);
+    /// <summary>Inequality operator.</summary>
     public static bool operator !=(MtstEntry300 left, MtstEntry300 right) => !left.Equals(right);
 
+    /// <inheritdoc/>
     public override string ToString() =>
         $"Index={MatdIndex}, State={MaterialState}, Variant=0x{MaterialVariant:X8}";
 }

--- a/src/TS4Tools.Wrappers/MeshChunks/Blocks/RsltBlock.cs
+++ b/src/TS4Tools.Wrappers/MeshChunks/Blocks/RsltBlock.cs
@@ -524,10 +524,16 @@ public sealed class RsltBlock : RcolBlock
 /// </summary>
 public readonly struct RsltMatrixRow
 {
+    /// <summary>First component.</summary>
     public float R1 { get; }
+    /// <summary>Second component.</summary>
     public float R2 { get; }
+    /// <summary>Third component.</summary>
     public float R3 { get; }
 
+    /// <summary>
+    /// Creates a new matrix row.
+    /// </summary>
     public RsltMatrixRow(float r1, float r2, float r3)
     {
         R1 = r1;
@@ -542,10 +548,16 @@ public readonly struct RsltMatrixRow
 /// </summary>
 public sealed class RsltSlotOffset
 {
+    /// <summary>Index of the slot.</summary>
     public int SlotIndex { get; }
+    /// <summary>Position offset.</summary>
     public MeshVector3 Position { get; }
+    /// <summary>Rotation offset.</summary>
     public MeshVector3 Rotation { get; }
 
+    /// <summary>
+    /// Creates a new slot offset.
+    /// </summary>
     public RsltSlotOffset(int slotIndex, MeshVector3 position, MeshVector3 rotation)
     {
         SlotIndex = slotIndex;
@@ -560,13 +572,22 @@ public sealed class RsltSlotOffset
 /// </summary>
 public class RsltPart
 {
+    /// <summary>FNV32 hash of the slot name.</summary>
     public uint SlotNameHash { get; }
+    /// <summary>FNV32 hash of the bone name.</summary>
     public uint BoneNameHash { get; }
+    /// <summary>X-axis rotation matrix row.</summary>
     public RsltMatrixRow MatrixX { get; }
+    /// <summary>Y-axis rotation matrix row.</summary>
     public RsltMatrixRow MatrixY { get; }
+    /// <summary>Z-axis rotation matrix row.</summary>
     public RsltMatrixRow MatrixZ { get; }
+    /// <summary>Position coordinates.</summary>
     public MeshVector3 Coordinates { get; }
 
+    /// <summary>
+    /// Creates a new slot part.
+    /// </summary>
     public RsltPart(uint slotNameHash, uint boneNameHash,
         RsltMatrixRow matrixX, RsltMatrixRow matrixY, RsltMatrixRow matrixZ,
         MeshVector3 coordinates)
@@ -586,11 +607,18 @@ public class RsltPart
 /// </summary>
 public sealed class RsltSlottedPart : RsltPart
 {
+    /// <summary>Size category of the slot.</summary>
     public byte SlotSize { get; }
+    /// <summary>Bitfield indicating allowed object types.</summary>
     public ulong SlotTypeSet { get; }
+    /// <summary>Whether slot direction is locked.</summary>
     public bool SlotDirectionLocked { get; }
+    /// <summary>Legacy slot hash for compatibility.</summary>
     public uint SlotLegacyHash { get; }
 
+    /// <summary>
+    /// Creates a new slotted part.
+    /// </summary>
     public RsltSlottedPart(uint slotNameHash, uint boneNameHash,
         RsltMatrixRow matrixX, RsltMatrixRow matrixY, RsltMatrixRow matrixZ,
         MeshVector3 coordinates,
@@ -610,9 +638,14 @@ public sealed class RsltSlottedPart : RsltPart
 /// </summary>
 public readonly struct RsltConeElement
 {
+    /// <summary>Radius of the cone.</summary>
     public float Radius { get; }
+    /// <summary>Angle of the cone in radians.</summary>
     public float Angle { get; }
 
+    /// <summary>
+    /// Creates a new cone element.
+    /// </summary>
     public RsltConeElement(float radius, float angle)
     {
         Radius = radius;
@@ -626,13 +659,22 @@ public readonly struct RsltConeElement
 /// </summary>
 public sealed class RsltConePart
 {
+    /// <summary>FNV32 hash of the slot name.</summary>
     public uint SlotNameHash { get; }
+    /// <summary>FNV32 hash of the bone name.</summary>
     public uint BoneNameHash { get; }
+    /// <summary>X-axis rotation matrix row.</summary>
     public RsltMatrixRow MatrixX { get; }
+    /// <summary>Y-axis rotation matrix row.</summary>
     public RsltMatrixRow MatrixY { get; }
+    /// <summary>Z-axis rotation matrix row.</summary>
     public RsltMatrixRow MatrixZ { get; }
+    /// <summary>Cone definition with radius and angle.</summary>
     public RsltConeElement Cone { get; }
 
+    /// <summary>
+    /// Creates a new cone part.
+    /// </summary>
     public RsltConePart(uint slotNameHash, uint boneNameHash,
         RsltMatrixRow matrixX, RsltMatrixRow matrixY, RsltMatrixRow matrixZ,
         RsltConeElement cone)

--- a/src/TS4Tools.Wrappers/MeshChunks/Blocks/SkinBlock.cs
+++ b/src/TS4Tools.Wrappers/MeshChunks/Blocks/SkinBlock.cs
@@ -13,23 +13,33 @@ public sealed class Bone : IEquatable<Bone>
     /// <summary>Inverse bind pose transformation matrix.</summary>
     public Matrix43 InverseBindPose { get; set; }
 
+    /// <summary>
+    /// Creates a new bone with identity transform.
+    /// </summary>
     public Bone()
     {
         InverseBindPose = Matrix43.Identity;
     }
 
+    /// <summary>
+    /// Creates a new bone with specified properties.
+    /// </summary>
     public Bone(uint nameHash, Matrix43 inverseBindPose)
     {
         NameHash = nameHash;
         InverseBindPose = inverseBindPose;
     }
 
+    /// <inheritdoc/>
     public bool Equals(Bone? other) =>
         other is not null && NameHash == other.NameHash && InverseBindPose == other.InverseBindPose;
 
+    /// <inheritdoc/>
     public override bool Equals(object? obj) => obj is Bone other && Equals(other);
+    /// <inheritdoc/>
     public override int GetHashCode() => HashCode.Combine(NameHash, InverseBindPose);
 
+    /// <inheritdoc/>
     public override string ToString() => $"Bone 0x{NameHash:X8}";
 }
 

--- a/src/TS4Tools.Wrappers/MeshChunks/Blocks/VbufBlock.cs
+++ b/src/TS4Tools.Wrappers/MeshChunks/Blocks/VbufBlock.cs
@@ -160,6 +160,13 @@ public sealed class Vbuf2Block : VbufBlock
     /// <inheritdoc/>
     public override uint ResourceType => TypeId;
 
+    /// <summary>
+    /// Creates an empty VBUF2 block.
+    /// </summary>
     public Vbuf2Block() : base() { }
+
+    /// <summary>
+    /// Creates a VBUF2 block from raw data.
+    /// </summary>
     public Vbuf2Block(ReadOnlySpan<byte> data) : base(data) { }
 }

--- a/src/TS4Tools.Wrappers/MeshChunks/Blocks/VpxyBlock.cs
+++ b/src/TS4Tools.Wrappers/MeshChunks/Blocks/VpxyBlock.cs
@@ -315,6 +315,9 @@ public sealed class VpxyEntry00 : VpxyEntry
     /// <summary>List of TGI indices (each stored as a byte in legacy).</summary>
     public IReadOnlyList<int> TgiIndices { get; }
 
+    /// <summary>
+    /// Creates a new entry with ID and TGI indices.
+    /// </summary>
     public VpxyEntry00(byte entryId, IReadOnlyList<int> tgiIndices)
     {
         EntryId = entryId;
@@ -346,6 +349,9 @@ public sealed class VpxyEntry01 : VpxyEntry
     /// <summary>TGI index reference.</summary>
     public int TgiIndex { get; }
 
+    /// <summary>
+    /// Creates a new entry with a TGI index.
+    /// </summary>
     public VpxyEntry01(int tgiIndex)
     {
         TgiIndex = tgiIndex;

--- a/src/TS4Tools.Wrappers/MeshChunks/Blocks/VrtfBlock.cs
+++ b/src/TS4Tools.Wrappers/MeshChunks/Blocks/VrtfBlock.cs
@@ -22,6 +22,9 @@ public readonly struct ElementLayout : IEquatable<ElementLayout>
     /// <summary>Byte offset within the vertex stride.</summary>
     public byte Offset { get; }
 
+    /// <summary>
+    /// Creates a new element layout.
+    /// </summary>
     public ElementLayout(ElementUsage usage, byte usageIndex, ElementFormat format, byte offset)
     {
         Usage = usage;
@@ -55,15 +58,21 @@ public readonly struct ElementLayout : IEquatable<ElementLayout>
         position += Size;
     }
 
+    /// <inheritdoc/>
     public bool Equals(ElementLayout other) =>
         Usage == other.Usage && UsageIndex == other.UsageIndex &&
         Format == other.Format && Offset == other.Offset;
 
+    /// <inheritdoc/>
     public override bool Equals(object? obj) => obj is ElementLayout other && Equals(other);
+    /// <inheritdoc/>
     public override int GetHashCode() => HashCode.Combine(Usage, UsageIndex, Format, Offset);
+    /// <summary>Equality operator.</summary>
     public static bool operator ==(ElementLayout left, ElementLayout right) => left.Equals(right);
+    /// <summary>Inequality operator.</summary>
     public static bool operator !=(ElementLayout left, ElementLayout right) => !left.Equals(right);
 
+    /// <inheritdoc/>
     public override string ToString() =>
         $"{Usage}[{UsageIndex}]: {Format} @ offset 0x{Offset:X2}";
 }

--- a/src/TS4Tools.Wrappers/MeshChunks/Common/BoundingBox.cs
+++ b/src/TS4Tools.Wrappers/MeshChunks/Common/BoundingBox.cs
@@ -16,6 +16,9 @@ public readonly struct BoundingBox : IEquatable<BoundingBox>
     /// <summary>Maximum corner of the bounding box.</summary>
     public MeshVector3 Max { get; }
 
+    /// <summary>
+    /// Initializes a new bounding box with the specified minimum and maximum corners.
+    /// </summary>
     public BoundingBox(MeshVector3 min, MeshVector3 max)
     {
         Min = min;
@@ -54,11 +57,17 @@ public readonly struct BoundingBox : IEquatable<BoundingBox>
     /// </summary>
     public static BoundingBox Empty => new(MeshVector3.Zero, MeshVector3.Zero);
 
+    /// <inheritdoc/>
     public bool Equals(BoundingBox other) => Min == other.Min && Max == other.Max;
+    /// <inheritdoc/>
     public override bool Equals(object? obj) => obj is BoundingBox other && Equals(other);
+    /// <inheritdoc/>
     public override int GetHashCode() => HashCode.Combine(Min, Max);
+    /// <summary>Equality operator.</summary>
     public static bool operator ==(BoundingBox left, BoundingBox right) => left.Equals(right);
+    /// <summary>Inequality operator.</summary>
     public static bool operator !=(BoundingBox left, BoundingBox right) => !left.Equals(right);
 
+    /// <inheritdoc/>
     public override string ToString() => $"[ Min: {Min} | Max: {Max} ]";
 }

--- a/src/TS4Tools.Wrappers/MeshChunks/Common/Matrix43.cs
+++ b/src/TS4Tools.Wrappers/MeshChunks/Common/Matrix43.cs
@@ -25,6 +25,9 @@ public readonly struct Matrix43 : IEquatable<Matrix43>
     /// <summary>The translation column vector.</summary>
     public MeshVector3 Translate { get; }
 
+    /// <summary>
+    /// Initializes a new 4x3 transformation matrix with the specified column vectors.
+    /// </summary>
     public Matrix43(MeshVector3 right, MeshVector3 up, MeshVector3 back, MeshVector3 translate)
     {
         Right = right;
@@ -109,13 +112,19 @@ public readonly struct Matrix43 : IEquatable<Matrix43>
         position += Size;
     }
 
+    /// <inheritdoc/>
     public bool Equals(Matrix43 other) =>
         Right == other.Right && Up == other.Up && Back == other.Back && Translate == other.Translate;
 
+    /// <inheritdoc/>
     public override bool Equals(object? obj) => obj is Matrix43 other && Equals(other);
+    /// <inheritdoc/>
     public override int GetHashCode() => HashCode.Combine(Right, Up, Back, Translate);
+    /// <summary>Equality operator.</summary>
     public static bool operator ==(Matrix43 left, Matrix43 right) => left.Equals(right);
+    /// <summary>Inequality operator.</summary>
     public static bool operator !=(Matrix43 left, Matrix43 right) => !left.Equals(right);
 
+    /// <inheritdoc/>
     public override string ToString() => $"{Right},{Up},{Back},{Translate}";
 }

--- a/src/TS4Tools.Wrappers/MeshChunks/Common/MeshVector2.cs
+++ b/src/TS4Tools.Wrappers/MeshChunks/Common/MeshVector2.cs
@@ -10,9 +10,14 @@ public readonly struct MeshVector2 : IEquatable<MeshVector2>
     /// <summary>Size in bytes when serialized.</summary>
     public const int Size = 8;
 
+    /// <summary>The X component.</summary>
     public float X { get; }
+    /// <summary>The Y component.</summary>
     public float Y { get; }
 
+    /// <summary>
+    /// Initializes a new 2D vector with the specified components.
+    /// </summary>
     public MeshVector2(float x, float y)
     {
         X = x;
@@ -40,14 +45,22 @@ public readonly struct MeshVector2 : IEquatable<MeshVector2>
         position += Size;
     }
 
+    /// <summary>Returns a zero vector (0, 0).</summary>
     public static MeshVector2 Zero => new(0, 0);
+    /// <summary>Returns a vector with all components set to one (1, 1).</summary>
     public static MeshVector2 One => new(1, 1);
 
+    /// <inheritdoc/>
     public bool Equals(MeshVector2 other) => X == other.X && Y == other.Y;
+    /// <inheritdoc/>
     public override bool Equals(object? obj) => obj is MeshVector2 other && Equals(other);
+    /// <inheritdoc/>
     public override int GetHashCode() => HashCode.Combine(X, Y);
+    /// <summary>Equality operator.</summary>
     public static bool operator ==(MeshVector2 left, MeshVector2 right) => left.Equals(right);
+    /// <summary>Inequality operator.</summary>
     public static bool operator !=(MeshVector2 left, MeshVector2 right) => !left.Equals(right);
 
+    /// <inheritdoc/>
     public override string ToString() => $"[{X,8:0.00000},{Y,8:0.00000}]";
 }

--- a/src/TS4Tools.Wrappers/MeshChunks/Common/MeshVector3.cs
+++ b/src/TS4Tools.Wrappers/MeshChunks/Common/MeshVector3.cs
@@ -10,10 +10,16 @@ public readonly struct MeshVector3 : IEquatable<MeshVector3>
     /// <summary>Size in bytes when serialized.</summary>
     public const int Size = 12;
 
+    /// <summary>The X component.</summary>
     public float X { get; }
+    /// <summary>The Y component.</summary>
     public float Y { get; }
+    /// <summary>The Z component.</summary>
     public float Z { get; }
 
+    /// <summary>
+    /// Initializes a new 3D vector with the specified components.
+    /// </summary>
     public MeshVector3(float x, float y, float z)
     {
         X = x;
@@ -44,17 +50,28 @@ public readonly struct MeshVector3 : IEquatable<MeshVector3>
         position += Size;
     }
 
+    /// <summary>Returns a zero vector (0, 0, 0).</summary>
     public static MeshVector3 Zero => new(0, 0, 0);
+    /// <summary>Returns a vector with all components set to one (1, 1, 1).</summary>
     public static MeshVector3 One => new(1, 1, 1);
+    /// <summary>Returns the X-axis unit vector (1, 0, 0).</summary>
     public static MeshVector3 UnitX => new(1, 0, 0);
+    /// <summary>Returns the Y-axis unit vector (0, 1, 0).</summary>
     public static MeshVector3 UnitY => new(0, 1, 0);
+    /// <summary>Returns the Z-axis unit vector (0, 0, 1).</summary>
     public static MeshVector3 UnitZ => new(0, 0, 1);
 
+    /// <inheritdoc/>
     public bool Equals(MeshVector3 other) => X == other.X && Y == other.Y && Z == other.Z;
+    /// <inheritdoc/>
     public override bool Equals(object? obj) => obj is MeshVector3 other && Equals(other);
+    /// <inheritdoc/>
     public override int GetHashCode() => HashCode.Combine(X, Y, Z);
+    /// <summary>Equality operator.</summary>
     public static bool operator ==(MeshVector3 left, MeshVector3 right) => left.Equals(right);
+    /// <summary>Inequality operator.</summary>
     public static bool operator !=(MeshVector3 left, MeshVector3 right) => !left.Equals(right);
 
+    /// <inheritdoc/>
     public override string ToString() => $"[{X,8:0.00000},{Y,8:0.00000},{Z,8:0.00000}]";
 }

--- a/src/TS4Tools.Wrappers/MeshChunks/Common/MeshVector4.cs
+++ b/src/TS4Tools.Wrappers/MeshChunks/Common/MeshVector4.cs
@@ -10,11 +10,18 @@ public readonly struct MeshVector4 : IEquatable<MeshVector4>
     /// <summary>Size in bytes when serialized.</summary>
     public const int Size = 16;
 
+    /// <summary>The X component.</summary>
     public float X { get; }
+    /// <summary>The Y component.</summary>
     public float Y { get; }
+    /// <summary>The Z component.</summary>
     public float Z { get; }
+    /// <summary>The W component.</summary>
     public float W { get; }
 
+    /// <summary>
+    /// Initializes a new 4D vector with the specified components.
+    /// </summary>
     public MeshVector4(float x, float y, float z, float w)
     {
         X = x;
@@ -48,14 +55,22 @@ public readonly struct MeshVector4 : IEquatable<MeshVector4>
         position += Size;
     }
 
+    /// <summary>Returns a zero vector (0, 0, 0, 0).</summary>
     public static MeshVector4 Zero => new(0, 0, 0, 0);
+    /// <summary>Returns a vector with all components set to one (1, 1, 1, 1).</summary>
     public static MeshVector4 One => new(1, 1, 1, 1);
 
+    /// <inheritdoc/>
     public bool Equals(MeshVector4 other) => X == other.X && Y == other.Y && Z == other.Z && W == other.W;
+    /// <inheritdoc/>
     public override bool Equals(object? obj) => obj is MeshVector4 other && Equals(other);
+    /// <inheritdoc/>
     public override int GetHashCode() => HashCode.Combine(X, Y, Z, W);
+    /// <summary>Equality operator.</summary>
     public static bool operator ==(MeshVector4 left, MeshVector4 right) => left.Equals(right);
+    /// <summary>Inequality operator.</summary>
     public static bool operator !=(MeshVector4 left, MeshVector4 right) => !left.Equals(right);
 
+    /// <inheritdoc/>
     public override string ToString() => $"[{X,8:0.00000},{Y,8:0.00000},{Z,8:0.00000},{W,8:0.00000}]";
 }

--- a/src/TS4Tools.Wrappers/MeshChunks/Common/UByte4.cs
+++ b/src/TS4Tools.Wrappers/MeshChunks/Common/UByte4.cs
@@ -9,11 +9,18 @@ public readonly struct UByte4 : IEquatable<UByte4>
     /// <summary>Size in bytes when serialized.</summary>
     public const int Size = 4;
 
+    /// <summary>The first byte component.</summary>
     public byte A { get; }
+    /// <summary>The second byte component.</summary>
     public byte B { get; }
+    /// <summary>The third byte component.</summary>
     public byte C { get; }
+    /// <summary>The fourth byte component.</summary>
     public byte D { get; }
 
+    /// <summary>
+    /// Initializes a new UByte4 with the specified byte components.
+    /// </summary>
     public UByte4(byte a, byte b, byte c, byte d)
     {
         A = a;
@@ -60,13 +67,20 @@ public readonly struct UByte4 : IEquatable<UByte4>
     /// </summary>
     public uint ToPacked() => A | ((uint)B << 8) | ((uint)C << 16) | ((uint)D << 24);
 
+    /// <summary>Returns a zero value (0, 0, 0, 0).</summary>
     public static UByte4 Zero => new(0, 0, 0, 0);
 
+    /// <inheritdoc/>
     public bool Equals(UByte4 other) => A == other.A && B == other.B && C == other.C && D == other.D;
+    /// <inheritdoc/>
     public override bool Equals(object? obj) => obj is UByte4 other && Equals(other);
+    /// <inheritdoc/>
     public override int GetHashCode() => HashCode.Combine(A, B, C, D);
+    /// <summary>Equality operator.</summary>
     public static bool operator ==(UByte4 left, UByte4 right) => left.Equals(right);
+    /// <summary>Inequality operator.</summary>
     public static bool operator !=(UByte4 left, UByte4 right) => !left.Equals(right);
 
+    /// <inheritdoc/>
     public override string ToString() => $"[{A:X2},{B:X2},{C:X2},{D:X2}]";
 }

--- a/src/TS4Tools.Wrappers/MeshChunks/Geometry/Face.cs
+++ b/src/TS4Tools.Wrappers/MeshChunks/Geometry/Face.cs
@@ -54,6 +54,9 @@ public readonly struct GeomFace : IEquatable<GeomFace>
         writer.Write(VertexIndex2);
     }
 
+    /// <summary>
+    /// Compares this face with another for equality.
+    /// </summary>
     public bool Equals(GeomFace other)
     {
         return VertexIndex0 == other.VertexIndex0
@@ -61,14 +64,30 @@ public readonly struct GeomFace : IEquatable<GeomFace>
             && VertexIndex2 == other.VertexIndex2;
     }
 
+    /// <summary>
+    /// Compares this face with an object for equality.
+    /// </summary>
     public override bool Equals(object? obj) => obj is GeomFace other && Equals(other);
 
+    /// <summary>
+    /// Gets a hash code for this face.
+    /// </summary>
     public override int GetHashCode() =>
         HashCode.Combine(VertexIndex0, VertexIndex1, VertexIndex2);
 
+    /// <summary>
+    /// Compares two faces for equality.
+    /// </summary>
     public static bool operator ==(GeomFace left, GeomFace right) => left.Equals(right);
+
+    /// <summary>
+    /// Compares two faces for inequality.
+    /// </summary>
     public static bool operator !=(GeomFace left, GeomFace right) => !left.Equals(right);
 
+    /// <summary>
+    /// Returns a string representation of this face.
+    /// </summary>
     public override string ToString() => $"Face({VertexIndex0}, {VertexIndex1}, {VertexIndex2})";
 }
 

--- a/src/TS4Tools.Wrappers/MeshChunks/Geometry/GeomUnknownTypes.cs
+++ b/src/TS4Tools.Wrappers/MeshChunks/Geometry/GeomUnknownTypes.cs
@@ -133,23 +133,58 @@ public sealed class GeomUnknownThing2
     /// <summary>Size in bytes when serialized (4+2+2+2+13*4+1 = 63 bytes).</summary>
     public const int Size = 63;
 
+    /// <summary>Unknown field 1 (uint).</summary>
     public uint Unknown1 { get; set; }
+
+    /// <summary>Unknown field 2 (ushort).</summary>
     public ushort Unknown2 { get; set; }
+
+    /// <summary>Unknown field 3 (ushort).</summary>
     public ushort Unknown3 { get; set; }
+
+    /// <summary>Unknown field 4 (ushort).</summary>
     public ushort Unknown4 { get; set; }
+
+    /// <summary>Unknown field 5 (float).</summary>
     public float Unknown5 { get; set; }
+
+    /// <summary>Unknown field 6 (float).</summary>
     public float Unknown6 { get; set; }
+
+    /// <summary>Unknown field 7 (float).</summary>
     public float Unknown7 { get; set; }
+
+    /// <summary>Unknown field 8 (float).</summary>
     public float Unknown8 { get; set; }
+
+    /// <summary>Unknown field 9 (float).</summary>
     public float Unknown9 { get; set; }
+
+    /// <summary>Unknown field 10 (float).</summary>
     public float Unknown10 { get; set; }
+
+    /// <summary>Unknown field 11 (float).</summary>
     public float Unknown11 { get; set; }
+
+    /// <summary>Unknown field 12 (float).</summary>
     public float Unknown12 { get; set; }
+
+    /// <summary>Unknown field 13 (float).</summary>
     public float Unknown13 { get; set; }
+
+    /// <summary>Unknown field 14 (float).</summary>
     public float Unknown14 { get; set; }
+
+    /// <summary>Unknown field 15 (float).</summary>
     public float Unknown15 { get; set; }
+
+    /// <summary>Unknown field 16 (float).</summary>
     public float Unknown16 { get; set; }
+
+    /// <summary>Unknown field 17 (float).</summary>
     public float Unknown17 { get; set; }
+
+    /// <summary>Unknown field 18 (byte).</summary>
     public byte Unknown18 { get; set; }
 
     /// <summary>

--- a/src/TS4Tools.Wrappers/MeshChunks/Geometry/VertexElements.cs
+++ b/src/TS4Tools.Wrappers/MeshChunks/Geometry/VertexElements.cs
@@ -18,7 +18,10 @@ public abstract class GeomVertexElement : IEquatable<GeomVertexElement>
     /// <summary>Compares two vertex elements for equality.</summary>
     public abstract bool Equals(GeomVertexElement? other);
 
+    /// <summary>Compares this element with an object for equality.</summary>
     public override bool Equals(object? obj) => obj is GeomVertexElement other && Equals(other);
+
+    /// <summary>Gets a hash code for this element.</summary>
     public abstract override int GetHashCode();
 }
 
@@ -28,15 +31,29 @@ public abstract class GeomVertexElement : IEquatable<GeomVertexElement>
 /// </summary>
 public sealed class PositionElement : GeomVertexElement
 {
+    /// <summary>The usage type for this element.</summary>
     public override GeomUsageType Usage => GeomUsageType.Position;
+
+    /// <summary>Size in bytes when serialized.</summary>
     public override int Size => 12;
 
+    /// <summary>X coordinate.</summary>
     public float X { get; set; }
+
+    /// <summary>Y coordinate.</summary>
     public float Y { get; set; }
+
+    /// <summary>Z coordinate.</summary>
     public float Z { get; set; }
 
+    /// <summary>
+    /// Creates an empty position element.
+    /// </summary>
     public PositionElement() { }
 
+    /// <summary>
+    /// Creates a position element with the specified coordinates.
+    /// </summary>
     public PositionElement(float x, float y, float z)
     {
         X = x;
@@ -44,6 +61,9 @@ public sealed class PositionElement : GeomVertexElement
         Z = z;
     }
 
+    /// <summary>
+    /// Reads a position element from the span.
+    /// </summary>
     public static PositionElement Read(ReadOnlySpan<byte> data, ref int position)
     {
         var element = new PositionElement
@@ -56,6 +76,9 @@ public sealed class PositionElement : GeomVertexElement
         return element;
     }
 
+    /// <summary>
+    /// Writes the position element to a binary writer.
+    /// </summary>
     public override void Write(BinaryWriter writer)
     {
         writer.Write(X);
@@ -63,12 +86,22 @@ public sealed class PositionElement : GeomVertexElement
         writer.Write(Z);
     }
 
+    /// <summary>
+    /// Compares this position element with another vertex element for equality.
+    /// </summary>
     public override bool Equals(GeomVertexElement? other)
     {
         return other is PositionElement p && X == p.X && Y == p.Y && Z == p.Z;
     }
 
+    /// <summary>
+    /// Gets a hash code for this position element.
+    /// </summary>
     public override int GetHashCode() => HashCode.Combine(X, Y, Z);
+
+    /// <summary>
+    /// Returns a string representation of this position element.
+    /// </summary>
     public override string ToString() => $"Position({X:F3}, {Y:F3}, {Z:F3})";
 }
 
@@ -78,15 +111,29 @@ public sealed class PositionElement : GeomVertexElement
 /// </summary>
 public sealed class NormalElement : GeomVertexElement
 {
+    /// <summary>The usage type for this element.</summary>
     public override GeomUsageType Usage => GeomUsageType.Normal;
+
+    /// <summary>Size in bytes when serialized.</summary>
     public override int Size => 12;
 
+    /// <summary>X component of the normal vector.</summary>
     public float X { get; set; }
+
+    /// <summary>Y component of the normal vector.</summary>
     public float Y { get; set; }
+
+    /// <summary>Z component of the normal vector.</summary>
     public float Z { get; set; }
 
+    /// <summary>
+    /// Creates an empty normal element.
+    /// </summary>
     public NormalElement() { }
 
+    /// <summary>
+    /// Creates a normal element with the specified vector components.
+    /// </summary>
     public NormalElement(float x, float y, float z)
     {
         X = x;
@@ -94,6 +141,9 @@ public sealed class NormalElement : GeomVertexElement
         Z = z;
     }
 
+    /// <summary>
+    /// Reads a normal element from the span.
+    /// </summary>
     public static NormalElement Read(ReadOnlySpan<byte> data, ref int position)
     {
         var element = new NormalElement
@@ -106,6 +156,9 @@ public sealed class NormalElement : GeomVertexElement
         return element;
     }
 
+    /// <summary>
+    /// Writes the normal element to a binary writer.
+    /// </summary>
     public override void Write(BinaryWriter writer)
     {
         writer.Write(X);
@@ -113,12 +166,22 @@ public sealed class NormalElement : GeomVertexElement
         writer.Write(Z);
     }
 
+    /// <summary>
+    /// Compares this normal element with another vertex element for equality.
+    /// </summary>
     public override bool Equals(GeomVertexElement? other)
     {
         return other is NormalElement n && X == n.X && Y == n.Y && Z == n.Z;
     }
 
+    /// <summary>
+    /// Gets a hash code for this normal element.
+    /// </summary>
     public override int GetHashCode() => HashCode.Combine(X, Y, Z);
+
+    /// <summary>
+    /// Returns a string representation of this normal element.
+    /// </summary>
     public override string ToString() => $"Normal({X:F3}, {Y:F3}, {Z:F3})";
 }
 
@@ -128,20 +191,35 @@ public sealed class NormalElement : GeomVertexElement
 /// </summary>
 public sealed class UVElement : GeomVertexElement
 {
+    /// <summary>The usage type for this element.</summary>
     public override GeomUsageType Usage => GeomUsageType.UV;
+
+    /// <summary>Size in bytes when serialized.</summary>
     public override int Size => 8;
 
+    /// <summary>U texture coordinate.</summary>
     public float U { get; set; }
+
+    /// <summary>V texture coordinate.</summary>
     public float V { get; set; }
 
+    /// <summary>
+    /// Creates an empty UV element.
+    /// </summary>
     public UVElement() { }
 
+    /// <summary>
+    /// Creates a UV element with the specified texture coordinates.
+    /// </summary>
     public UVElement(float u, float v)
     {
         U = u;
         V = v;
     }
 
+    /// <summary>
+    /// Reads a UV element from the span.
+    /// </summary>
     public static UVElement Read(ReadOnlySpan<byte> data, ref int position)
     {
         var element = new UVElement
@@ -153,18 +231,31 @@ public sealed class UVElement : GeomVertexElement
         return element;
     }
 
+    /// <summary>
+    /// Writes the UV element to a binary writer.
+    /// </summary>
     public override void Write(BinaryWriter writer)
     {
         writer.Write(U);
         writer.Write(V);
     }
 
+    /// <summary>
+    /// Compares this UV element with another vertex element for equality.
+    /// </summary>
     public override bool Equals(GeomVertexElement? other)
     {
         return other is UVElement uv && U == uv.U && V == uv.V;
     }
 
+    /// <summary>
+    /// Gets a hash code for this UV element.
+    /// </summary>
     public override int GetHashCode() => HashCode.Combine(U, V);
+
+    /// <summary>
+    /// Returns a string representation of this UV element.
+    /// </summary>
     public override string ToString() => $"UV({U:F3}, {V:F3})";
 }
 
@@ -174,18 +265,31 @@ public sealed class UVElement : GeomVertexElement
 /// </summary>
 public sealed class BoneAssignmentElement : GeomVertexElement
 {
+    /// <summary>The usage type for this element.</summary>
     public override GeomUsageType Usage => GeomUsageType.BoneAssignment;
+
+    /// <summary>Size in bytes when serialized.</summary>
     public override int Size => 4;
 
+    /// <summary>Bone assignment identifier.</summary>
     public uint Id { get; set; }
 
+    /// <summary>
+    /// Creates an empty bone assignment element.
+    /// </summary>
     public BoneAssignmentElement() { }
 
+    /// <summary>
+    /// Creates a bone assignment element with the specified ID.
+    /// </summary>
     public BoneAssignmentElement(uint id)
     {
         Id = id;
     }
 
+    /// <summary>
+    /// Reads a bone assignment element from the span.
+    /// </summary>
     public static BoneAssignmentElement Read(ReadOnlySpan<byte> data, ref int position)
     {
         var element = new BoneAssignmentElement
@@ -196,17 +300,30 @@ public sealed class BoneAssignmentElement : GeomVertexElement
         return element;
     }
 
+    /// <summary>
+    /// Writes the bone assignment element to a binary writer.
+    /// </summary>
     public override void Write(BinaryWriter writer)
     {
         writer.Write(Id);
     }
 
+    /// <summary>
+    /// Compares this bone assignment element with another vertex element for equality.
+    /// </summary>
     public override bool Equals(GeomVertexElement? other)
     {
         return other is BoneAssignmentElement b && Id == b.Id;
     }
 
+    /// <summary>
+    /// Gets a hash code for this bone assignment element.
+    /// </summary>
     public override int GetHashCode() => Id.GetHashCode();
+
+    /// <summary>
+    /// Returns a string representation of this bone assignment element.
+    /// </summary>
     public override string ToString() => $"BoneAssignment({Id})";
 }
 
@@ -217,16 +334,32 @@ public sealed class BoneAssignmentElement : GeomVertexElement
 /// </summary>
 public sealed class WeightsElement : GeomVertexElement
 {
+    /// <summary>The usage type for this element.</summary>
     public override GeomUsageType Usage => GeomUsageType.Weights;
+
+    /// <summary>Size in bytes when serialized.</summary>
     public override int Size => 16;
 
+    /// <summary>First bone weight value.</summary>
     public float W1 { get; set; }
+
+    /// <summary>Second bone weight value.</summary>
     public float W2 { get; set; }
+
+    /// <summary>Third bone weight value.</summary>
     public float W3 { get; set; }
+
+    /// <summary>Fourth bone weight value.</summary>
     public float W4 { get; set; }
 
+    /// <summary>
+    /// Creates an empty weights element.
+    /// </summary>
     public WeightsElement() { }
 
+    /// <summary>
+    /// Creates a weights element with the specified weight values.
+    /// </summary>
     public WeightsElement(float w1, float w2, float w3, float w4)
     {
         W1 = w1;
@@ -235,6 +368,9 @@ public sealed class WeightsElement : GeomVertexElement
         W4 = w4;
     }
 
+    /// <summary>
+    /// Reads a weights element from the span.
+    /// </summary>
     public static WeightsElement Read(ReadOnlySpan<byte> data, ref int position)
     {
         var element = new WeightsElement
@@ -248,6 +384,9 @@ public sealed class WeightsElement : GeomVertexElement
         return element;
     }
 
+    /// <summary>
+    /// Writes the weights element to a binary writer.
+    /// </summary>
     public override void Write(BinaryWriter writer)
     {
         writer.Write(W1);
@@ -256,12 +395,22 @@ public sealed class WeightsElement : GeomVertexElement
         writer.Write(W4);
     }
 
+    /// <summary>
+    /// Compares this weights element with another vertex element for equality.
+    /// </summary>
     public override bool Equals(GeomVertexElement? other)
     {
         return other is WeightsElement w && W1 == w.W1 && W2 == w.W2 && W3 == w.W3 && W4 == w.W4;
     }
 
+    /// <summary>
+    /// Gets a hash code for this weights element.
+    /// </summary>
     public override int GetHashCode() => HashCode.Combine(W1, W2, W3, W4);
+
+    /// <summary>
+    /// Returns a string representation of this weights element.
+    /// </summary>
     public override string ToString() => $"Weights({W1:F3}, {W2:F3}, {W3:F3}, {W4:F3})";
 }
 
@@ -272,16 +421,32 @@ public sealed class WeightsElement : GeomVertexElement
 /// </summary>
 public sealed class WeightBytesElement : GeomVertexElement
 {
+    /// <summary>The usage type for this element.</summary>
     public override GeomUsageType Usage => GeomUsageType.Weights;
+
+    /// <summary>Size in bytes when serialized.</summary>
     public override int Size => 4;
 
+    /// <summary>First bone weight value (as byte).</summary>
     public byte W1 { get; set; }
+
+    /// <summary>Second bone weight value (as byte).</summary>
     public byte W2 { get; set; }
+
+    /// <summary>Third bone weight value (as byte).</summary>
     public byte W3 { get; set; }
+
+    /// <summary>Fourth bone weight value (as byte).</summary>
     public byte W4 { get; set; }
 
+    /// <summary>
+    /// Creates an empty weight bytes element.
+    /// </summary>
     public WeightBytesElement() { }
 
+    /// <summary>
+    /// Creates a weight bytes element with the specified weight values.
+    /// </summary>
     public WeightBytesElement(byte w1, byte w2, byte w3, byte w4)
     {
         W1 = w1;
@@ -290,6 +455,9 @@ public sealed class WeightBytesElement : GeomVertexElement
         W4 = w4;
     }
 
+    /// <summary>
+    /// Reads a weight bytes element from the span.
+    /// </summary>
     public static WeightBytesElement Read(ReadOnlySpan<byte> data, ref int position)
     {
         var element = new WeightBytesElement
@@ -303,6 +471,9 @@ public sealed class WeightBytesElement : GeomVertexElement
         return element;
     }
 
+    /// <summary>
+    /// Writes the weight bytes element to a binary writer.
+    /// </summary>
     public override void Write(BinaryWriter writer)
     {
         writer.Write(W1);
@@ -311,12 +482,22 @@ public sealed class WeightBytesElement : GeomVertexElement
         writer.Write(W4);
     }
 
+    /// <summary>
+    /// Compares this weight bytes element with another vertex element for equality.
+    /// </summary>
     public override bool Equals(GeomVertexElement? other)
     {
         return other is WeightBytesElement w && W1 == w.W1 && W2 == w.W2 && W3 == w.W3 && W4 == w.W4;
     }
 
+    /// <summary>
+    /// Gets a hash code for this weight bytes element.
+    /// </summary>
     public override int GetHashCode() => HashCode.Combine(W1, W2, W3, W4);
+
+    /// <summary>
+    /// Returns a string representation of this weight bytes element.
+    /// </summary>
     public override string ToString() => $"WeightBytes({W1}, {W2}, {W3}, {W4})";
 }
 
@@ -326,15 +507,29 @@ public sealed class WeightBytesElement : GeomVertexElement
 /// </summary>
 public sealed class TangentNormalElement : GeomVertexElement
 {
+    /// <summary>The usage type for this element.</summary>
     public override GeomUsageType Usage => GeomUsageType.TangentNormal;
+
+    /// <summary>Size in bytes when serialized.</summary>
     public override int Size => 12;
 
+    /// <summary>X component of the tangent normal vector.</summary>
     public float X { get; set; }
+
+    /// <summary>Y component of the tangent normal vector.</summary>
     public float Y { get; set; }
+
+    /// <summary>Z component of the tangent normal vector.</summary>
     public float Z { get; set; }
 
+    /// <summary>
+    /// Creates an empty tangent normal element.
+    /// </summary>
     public TangentNormalElement() { }
 
+    /// <summary>
+    /// Creates a tangent normal element with the specified vector components.
+    /// </summary>
     public TangentNormalElement(float x, float y, float z)
     {
         X = x;
@@ -342,6 +537,9 @@ public sealed class TangentNormalElement : GeomVertexElement
         Z = z;
     }
 
+    /// <summary>
+    /// Reads a tangent normal element from the span.
+    /// </summary>
     public static TangentNormalElement Read(ReadOnlySpan<byte> data, ref int position)
     {
         var element = new TangentNormalElement
@@ -354,6 +552,9 @@ public sealed class TangentNormalElement : GeomVertexElement
         return element;
     }
 
+    /// <summary>
+    /// Writes the tangent normal element to a binary writer.
+    /// </summary>
     public override void Write(BinaryWriter writer)
     {
         writer.Write(X);
@@ -361,12 +562,22 @@ public sealed class TangentNormalElement : GeomVertexElement
         writer.Write(Z);
     }
 
+    /// <summary>
+    /// Compares this tangent normal element with another vertex element for equality.
+    /// </summary>
     public override bool Equals(GeomVertexElement? other)
     {
         return other is TangentNormalElement t && X == t.X && Y == t.Y && Z == t.Z;
     }
 
+    /// <summary>
+    /// Gets a hash code for this tangent normal element.
+    /// </summary>
     public override int GetHashCode() => HashCode.Combine(X, Y, Z);
+
+    /// <summary>
+    /// Returns a string representation of this tangent normal element.
+    /// </summary>
     public override string ToString() => $"TangentNormal({X:F3}, {Y:F3}, {Z:F3})";
 }
 
@@ -376,18 +587,31 @@ public sealed class TangentNormalElement : GeomVertexElement
 /// </summary>
 public sealed class ColorElement : GeomVertexElement
 {
+    /// <summary>The usage type for this element.</summary>
     public override GeomUsageType Usage => GeomUsageType.Color;
+
+    /// <summary>Size in bytes when serialized.</summary>
     public override int Size => 4;
 
+    /// <summary>Color value in ARGB format.</summary>
     public int Argb { get; set; }
 
+    /// <summary>
+    /// Creates an empty color element.
+    /// </summary>
     public ColorElement() { }
 
+    /// <summary>
+    /// Creates a color element with the specified ARGB value.
+    /// </summary>
     public ColorElement(int argb)
     {
         Argb = argb;
     }
 
+    /// <summary>
+    /// Reads a color element from the span.
+    /// </summary>
     public static ColorElement Read(ReadOnlySpan<byte> data, ref int position)
     {
         var element = new ColorElement
@@ -398,22 +622,42 @@ public sealed class ColorElement : GeomVertexElement
         return element;
     }
 
+    /// <summary>
+    /// Writes the color element to a binary writer.
+    /// </summary>
     public override void Write(BinaryWriter writer)
     {
         writer.Write(Argb);
     }
 
+    /// <summary>Gets the alpha channel value (0-255).</summary>
     public byte A => (byte)((Argb >> 24) & 0xFF);
+
+    /// <summary>Gets the red channel value (0-255).</summary>
     public byte R => (byte)((Argb >> 16) & 0xFF);
+
+    /// <summary>Gets the green channel value (0-255).</summary>
     public byte G => (byte)((Argb >> 8) & 0xFF);
+
+    /// <summary>Gets the blue channel value (0-255).</summary>
     public byte B => (byte)(Argb & 0xFF);
 
+    /// <summary>
+    /// Compares this color element with another vertex element for equality.
+    /// </summary>
     public override bool Equals(GeomVertexElement? other)
     {
         return other is ColorElement c && Argb == c.Argb;
     }
 
+    /// <summary>
+    /// Gets a hash code for this color element.
+    /// </summary>
     public override int GetHashCode() => Argb.GetHashCode();
+
+    /// <summary>
+    /// Returns a string representation of this color element.
+    /// </summary>
     public override string ToString() => $"Color(A={A}, R={R}, G={G}, B={B})";
 }
 
@@ -423,18 +667,31 @@ public sealed class ColorElement : GeomVertexElement
 /// </summary>
 public sealed class VertexIDElement : GeomVertexElement
 {
+    /// <summary>The usage type for this element.</summary>
     public override GeomUsageType Usage => GeomUsageType.VertexID;
+
+    /// <summary>Size in bytes when serialized.</summary>
     public override int Size => 4;
 
+    /// <summary>Vertex identifier value.</summary>
     public uint Id { get; set; }
 
+    /// <summary>
+    /// Creates an empty vertex ID element.
+    /// </summary>
     public VertexIDElement() { }
 
+    /// <summary>
+    /// Creates a vertex ID element with the specified ID.
+    /// </summary>
     public VertexIDElement(uint id)
     {
         Id = id;
     }
 
+    /// <summary>
+    /// Reads a vertex ID element from the span.
+    /// </summary>
     public static VertexIDElement Read(ReadOnlySpan<byte> data, ref int position)
     {
         var element = new VertexIDElement
@@ -445,17 +702,30 @@ public sealed class VertexIDElement : GeomVertexElement
         return element;
     }
 
+    /// <summary>
+    /// Writes the vertex ID element to a binary writer.
+    /// </summary>
     public override void Write(BinaryWriter writer)
     {
         writer.Write(Id);
     }
 
+    /// <summary>
+    /// Compares this vertex ID element with another vertex element for equality.
+    /// </summary>
     public override bool Equals(GeomVertexElement? other)
     {
         return other is VertexIDElement v && Id == v.Id;
     }
 
+    /// <summary>
+    /// Gets a hash code for this vertex ID element.
+    /// </summary>
     public override int GetHashCode() => Id.GetHashCode();
+
+    /// <summary>
+    /// Returns a string representation of this vertex ID element.
+    /// </summary>
     public override string ToString() => $"VertexID({Id})";
 }
 
@@ -465,6 +735,9 @@ public sealed class VertexIDElement : GeomVertexElement
 /// </summary>
 public static class GeomVertexElementReader
 {
+    /// <summary>
+    /// Reads a vertex element from the span based on the usage type and GEOM version.
+    /// </summary>
     public static GeomVertexElement Read(
         ReadOnlySpan<byte> data,
         ref int position,

--- a/src/TS4Tools.Wrappers/MeshChunks/Geometry/VertexFormat.cs
+++ b/src/TS4Tools.Wrappers/MeshChunks/Geometry/VertexFormat.cs
@@ -143,7 +143,7 @@ public sealed class GeomVertexFormat : IEquatable<GeomVertexFormat>
     }
 
     /// <summary>
-    /// Gets the expected element size for a usage type and version.
+    /// Gets the expected element size in bytes for a usage type and GEOM version.
     /// Source: GEOM.cs lines 270-282 (v5) and 298-310 (v12)
     /// </summary>
     public static byte GetExpectedElementSize(GeomUsageType usage, uint version)
@@ -153,7 +153,7 @@ public sealed class GeomVertexFormat : IEquatable<GeomVertexFormat>
     }
 
     /// <summary>
-    /// Writes the vertex format to the span.
+    /// Writes the vertex format to a span at the specified position.
     /// Source: GEOM.cs lines 365-390
     /// </summary>
     public void Write(Span<byte> data, ref int position)
@@ -180,15 +180,28 @@ public sealed class GeomVertexFormat : IEquatable<GeomVertexFormat>
         writer.Write(GetExpectedElementSize(Usage, Version));
     }
 
+    /// <summary>
+    /// Compares this vertex format with another for equality.
+    /// </summary>
     public bool Equals(GeomVertexFormat? other)
     {
         if (other is null) return false;
         return Usage == other.Usage;
     }
 
+    /// <summary>
+    /// Compares this vertex format with an object for equality.
+    /// </summary>
     public override bool Equals(object? obj) => obj is GeomVertexFormat other && Equals(other);
+
+    /// <summary>
+    /// Gets a hash code for this vertex format.
+    /// </summary>
     public override int GetHashCode() => Usage.GetHashCode();
 
+    /// <summary>
+    /// Returns a string representation of this vertex format.
+    /// </summary>
     public override string ToString() => Usage.ToString();
 }
 
@@ -257,7 +270,7 @@ public sealed class GeomVertexFormatList
     }
 
     /// <summary>
-    /// Calculates the total byte size of one vertex based on this format list.
+    /// Calculates the total size in bytes of a single vertex based on this format list.
     /// </summary>
     public int CalculateVertexSize()
     {

--- a/src/TS4Tools.Wrappers/MeshChunks/ShaderData/ShaderDataElement.cs
+++ b/src/TS4Tools.Wrappers/MeshChunks/ShaderData/ShaderDataElement.cs
@@ -81,35 +81,54 @@ public abstract class ShaderDataElement
 /// <summary>Single float shader data.</summary>
 public sealed class ShaderFloat : ShaderDataElement
 {
+    /// <inheritdoc/>
     public override ShaderDataType DataType => ShaderDataType.Float;
+    /// <inheritdoc/>
     public override int Count => 1;
 
+    /// <summary>The float value.</summary>
     public float Value { get; set; }
 
+    /// <summary>Initializes a new instance of the <see cref="ShaderFloat"/> class.</summary>
+    /// <param name="field">The shader field type.</param>
+    /// <param name="value">The float value.</param>
     public ShaderFloat(ShaderFieldType field, float value = 0f)
     {
         Field = field;
         Value = value;
     }
 
+    /// <summary>Initializes a new instance of the <see cref="ShaderFloat"/> class from binary data.</summary>
+    /// <param name="field">The shader field type.</param>
+    /// <param name="data">The binary data to read from.</param>
+    /// <param name="offset">The offset in the data to start reading.</param>
     internal ShaderFloat(ShaderFieldType field, ReadOnlySpan<byte> data, int offset)
     {
         Field = field;
         Value = BinaryPrimitives.ReadSingleLittleEndian(data[offset..]);
     }
 
+    /// <inheritdoc/>
     public override void WriteData(BinaryWriter writer) => writer.Write(Value);
 }
 
 /// <summary>Float2 (vec2) shader data.</summary>
 public sealed class ShaderFloat2 : ShaderDataElement
 {
+    /// <inheritdoc/>
     public override ShaderDataType DataType => ShaderDataType.Float;
+    /// <inheritdoc/>
     public override int Count => 2;
 
+    /// <summary>The X component.</summary>
     public float X { get; set; }
+    /// <summary>The Y component.</summary>
     public float Y { get; set; }
 
+    /// <summary>Initializes a new instance of the <see cref="ShaderFloat2"/> class.</summary>
+    /// <param name="field">The shader field type.</param>
+    /// <param name="x">The X component.</param>
+    /// <param name="y">The Y component.</param>
     public ShaderFloat2(ShaderFieldType field, float x = 0f, float y = 0f)
     {
         Field = field;
@@ -117,6 +136,10 @@ public sealed class ShaderFloat2 : ShaderDataElement
         Y = y;
     }
 
+    /// <summary>Initializes a new instance of the <see cref="ShaderFloat2"/> class from binary data.</summary>
+    /// <param name="field">The shader field type.</param>
+    /// <param name="data">The binary data to read from.</param>
+    /// <param name="offset">The offset in the data to start reading.</param>
     internal ShaderFloat2(ShaderFieldType field, ReadOnlySpan<byte> data, int offset)
     {
         Field = field;
@@ -124,6 +147,7 @@ public sealed class ShaderFloat2 : ShaderDataElement
         Y = BinaryPrimitives.ReadSingleLittleEndian(data[(offset + 4)..]);
     }
 
+    /// <inheritdoc/>
     public override void WriteData(BinaryWriter writer)
     {
         writer.Write(X);
@@ -134,13 +158,23 @@ public sealed class ShaderFloat2 : ShaderDataElement
 /// <summary>Float3 (vec3) shader data.</summary>
 public sealed class ShaderFloat3 : ShaderDataElement
 {
+    /// <inheritdoc/>
     public override ShaderDataType DataType => ShaderDataType.Float;
+    /// <inheritdoc/>
     public override int Count => 3;
 
+    /// <summary>The X component.</summary>
     public float X { get; set; }
+    /// <summary>The Y component.</summary>
     public float Y { get; set; }
+    /// <summary>The Z component.</summary>
     public float Z { get; set; }
 
+    /// <summary>Initializes a new instance of the <see cref="ShaderFloat3"/> class.</summary>
+    /// <param name="field">The shader field type.</param>
+    /// <param name="x">The X component.</param>
+    /// <param name="y">The Y component.</param>
+    /// <param name="z">The Z component.</param>
     public ShaderFloat3(ShaderFieldType field, float x = 0f, float y = 0f, float z = 0f)
     {
         Field = field;
@@ -149,6 +183,10 @@ public sealed class ShaderFloat3 : ShaderDataElement
         Z = z;
     }
 
+    /// <summary>Initializes a new instance of the <see cref="ShaderFloat3"/> class from binary data.</summary>
+    /// <param name="field">The shader field type.</param>
+    /// <param name="data">The binary data to read from.</param>
+    /// <param name="offset">The offset in the data to start reading.</param>
     internal ShaderFloat3(ShaderFieldType field, ReadOnlySpan<byte> data, int offset)
     {
         Field = field;
@@ -157,6 +195,7 @@ public sealed class ShaderFloat3 : ShaderDataElement
         Z = BinaryPrimitives.ReadSingleLittleEndian(data[(offset + 8)..]);
     }
 
+    /// <inheritdoc/>
     public override void WriteData(BinaryWriter writer)
     {
         writer.Write(X);
@@ -168,14 +207,26 @@ public sealed class ShaderFloat3 : ShaderDataElement
 /// <summary>Float4 (vec4) shader data.</summary>
 public sealed class ShaderFloat4 : ShaderDataElement
 {
+    /// <inheritdoc/>
     public override ShaderDataType DataType => ShaderDataType.Float;
+    /// <inheritdoc/>
     public override int Count => 4;
 
+    /// <summary>The X component.</summary>
     public float X { get; set; }
+    /// <summary>The Y component.</summary>
     public float Y { get; set; }
+    /// <summary>The Z component.</summary>
     public float Z { get; set; }
+    /// <summary>The W component.</summary>
     public float W { get; set; }
 
+    /// <summary>Initializes a new instance of the <see cref="ShaderFloat4"/> class.</summary>
+    /// <param name="field">The shader field type.</param>
+    /// <param name="x">The X component.</param>
+    /// <param name="y">The Y component.</param>
+    /// <param name="z">The Z component.</param>
+    /// <param name="w">The W component.</param>
     public ShaderFloat4(ShaderFieldType field, float x = 0f, float y = 0f, float z = 0f, float w = 0f)
     {
         Field = field;
@@ -185,6 +236,10 @@ public sealed class ShaderFloat4 : ShaderDataElement
         W = w;
     }
 
+    /// <summary>Initializes a new instance of the <see cref="ShaderFloat4"/> class from binary data.</summary>
+    /// <param name="field">The shader field type.</param>
+    /// <param name="data">The binary data to read from.</param>
+    /// <param name="offset">The offset in the data to start reading.</param>
     internal ShaderFloat4(ShaderFieldType field, ReadOnlySpan<byte> data, int offset)
     {
         Field = field;
@@ -194,6 +249,7 @@ public sealed class ShaderFloat4 : ShaderDataElement
         W = BinaryPrimitives.ReadSingleLittleEndian(data[(offset + 12)..]);
     }
 
+    /// <inheritdoc/>
     public override void WriteData(BinaryWriter writer)
     {
         writer.Write(X);
@@ -206,41 +262,61 @@ public sealed class ShaderFloat4 : ShaderDataElement
 /// <summary>Integer shader data.</summary>
 public sealed class ShaderInt : ShaderDataElement
 {
+    /// <inheritdoc/>
     public override ShaderDataType DataType => ShaderDataType.Int;
+    /// <inheritdoc/>
     public override int Count => 1;
 
+    /// <summary>The integer value.</summary>
     public int Value { get; set; }
 
+    /// <summary>Initializes a new instance of the <see cref="ShaderInt"/> class.</summary>
+    /// <param name="field">The shader field type.</param>
+    /// <param name="value">The integer value.</param>
     public ShaderInt(ShaderFieldType field, int value = 0)
     {
         Field = field;
         Value = value;
     }
 
+    /// <summary>Initializes a new instance of the <see cref="ShaderInt"/> class from binary data.</summary>
+    /// <param name="field">The shader field type.</param>
+    /// <param name="data">The binary data to read from.</param>
+    /// <param name="offset">The offset in the data to start reading.</param>
     internal ShaderInt(ShaderFieldType field, ReadOnlySpan<byte> data, int offset)
     {
         Field = field;
         Value = BinaryPrimitives.ReadInt32LittleEndian(data[offset..]);
     }
 
+    /// <inheritdoc/>
     public override void WriteData(BinaryWriter writer) => writer.Write(Value);
 }
 
 /// <summary>Texture reference shader data (TGI key in ITG order).</summary>
 public sealed class ShaderTextureRef : ShaderDataElement
 {
+    /// <inheritdoc/>
     public override ShaderDataType DataType => ShaderDataType.Texture;
+    /// <inheritdoc/>
     public override int Count => 4;
 
     /// <summary>Texture resource key in ITG order.</summary>
     public ResourceKey TextureKey { get; set; }
 
+    /// <summary>Initializes a new instance of the <see cref="ShaderTextureRef"/> class.</summary>
+    /// <param name="field">The shader field type.</param>
+    /// <param name="key">The texture resource key.</param>
     public ShaderTextureRef(ShaderFieldType field, ResourceKey key = default)
     {
         Field = field;
         TextureKey = key;
     }
 
+    /// <summary>Initializes a new instance of the <see cref="ShaderTextureRef"/> class from binary data.</summary>
+    /// <param name="field">The shader field type.</param>
+    /// <param name="data">The binary data to read from.</param>
+    /// <param name="offset">The offset in the data to start reading.</param>
     internal ShaderTextureRef(ShaderFieldType field, ReadOnlySpan<byte> data, int offset)
     {
         Field = field;
@@ -251,6 +327,7 @@ public sealed class ShaderTextureRef : ShaderDataElement
         TextureKey = new ResourceKey(type, group, instance);
     }
 
+    /// <inheritdoc/>
     public override void WriteData(BinaryWriter writer)
     {
         // ITG order
@@ -263,7 +340,9 @@ public sealed class ShaderTextureRef : ShaderDataElement
 /// <summary>Texture key shader data (with additional format info).</summary>
 public sealed class ShaderTextureKey : ShaderDataElement
 {
+    /// <inheritdoc/>
     public override ShaderDataType DataType => ShaderDataType.Texture;
+    /// <inheritdoc/>
     public override int Count => 5;
 
     /// <summary>Texture resource key in ITG order.</summary>
@@ -272,6 +351,10 @@ public sealed class ShaderTextureKey : ShaderDataElement
     /// <summary>Additional format value.</summary>
     public uint Format { get; set; }
 
+    /// <summary>Initializes a new instance of the <see cref="ShaderTextureKey"/> class.</summary>
+    /// <param name="field">The shader field type.</param>
+    /// <param name="key">The texture resource key.</param>
+    /// <param name="format">The format value.</param>
     public ShaderTextureKey(ShaderFieldType field, ResourceKey key = default, uint format = 0)
     {
         Field = field;
@@ -279,6 +362,10 @@ public sealed class ShaderTextureKey : ShaderDataElement
         Format = format;
     }
 
+    /// <summary>Initializes a new instance of the <see cref="ShaderTextureKey"/> class from binary data.</summary>
+    /// <param name="field">The shader field type.</param>
+    /// <param name="data">The binary data to read from.</param>
+    /// <param name="offset">The offset in the data to start reading.</param>
     internal ShaderTextureKey(ShaderFieldType field, ReadOnlySpan<byte> data, int offset)
     {
         Field = field;
@@ -290,6 +377,7 @@ public sealed class ShaderTextureKey : ShaderDataElement
         Format = BinaryPrimitives.ReadUInt32LittleEndian(data[(offset + 16)..]);
     }
 
+    /// <inheritdoc/>
     public override void WriteData(BinaryWriter writer)
     {
         // ITG order
@@ -303,18 +391,27 @@ public sealed class ShaderTextureKey : ShaderDataElement
 /// <summary>Image map key shader data.</summary>
 public sealed class ShaderImageMapKey : ShaderDataElement
 {
+    /// <inheritdoc/>
     public override ShaderDataType DataType => ShaderDataType.ImageMap;
+    /// <inheritdoc/>
     public override int Count => 4;
 
     /// <summary>Image map resource key in ITG order.</summary>
     public ResourceKey ImageMapKey { get; set; }
 
+    /// <summary>Initializes a new instance of the <see cref="ShaderImageMapKey"/> class.</summary>
+    /// <param name="field">The shader field type.</param>
+    /// <param name="key">The image map resource key.</param>
     public ShaderImageMapKey(ShaderFieldType field, ResourceKey key = default)
     {
         Field = field;
         ImageMapKey = key;
     }
 
+    /// <summary>Initializes a new instance of the <see cref="ShaderImageMapKey"/> class from binary data.</summary>
+    /// <param name="field">The shader field type.</param>
+    /// <param name="data">The binary data to read from.</param>
+    /// <param name="offset">The offset in the data to start reading.</param>
     internal ShaderImageMapKey(ShaderFieldType field, ReadOnlySpan<byte> data, int offset)
     {
         Field = field;
@@ -325,6 +422,7 @@ public sealed class ShaderImageMapKey : ShaderDataElement
         ImageMapKey = new ResourceKey(type, group, instance);
     }
 
+    /// <inheritdoc/>
     public override void WriteData(BinaryWriter writer)
     {
         // ITG order

--- a/src/TS4Tools.Wrappers/MeshChunks/ShaderData/ShaderDataTypes.cs
+++ b/src/TS4Tools.Wrappers/MeshChunks/ShaderData/ShaderDataTypes.cs
@@ -11,10 +11,15 @@ namespace TS4Tools.Wrappers.MeshChunks;
 /// </summary>
 public enum ShaderDataType : uint
 {
+    /// <summary>Unknown shader data type.</summary>
     Unknown = 0,
+    /// <summary>Float data type (1-4 components).</summary>
     Float = 1,
+    /// <summary>Integer data type.</summary>
     Int = 2,
+    /// <summary>Texture reference data type.</summary>
     Texture = 4,
+    /// <summary>Image map data type.</summary>
     ImageMap = 0x00010004
 }
 
@@ -24,159 +29,299 @@ public enum ShaderDataType : uint
 /// </summary>
 public enum ShaderFieldType : uint
 {
+    /// <summary>No field type.</summary>
     None = 0x00000000,
 
     // Float fields
+    /// <summary>Align across direction (float).</summary>
     AlignAcrossDirection = 0x01885886,
+    /// <summary>Dimming center height (float).</summary>
     DimmingCenterHeight = 0x01ADACE0,
+    /// <summary>Transparency (float).</summary>
     Transparency = 0x05D22FD3,
+    /// <summary>Blend source mode (float).</summary>
     BlendSourceMode = 0x0995E96C,
+    /// <summary>Sharp specular control (float).</summary>
     SharpSpecControl = 0x11483F01,
+    /// <summary>Rotation speed in radians per second (float).</summary>
     RotateSpeedRadsSec = 0x16BF7A44,
+    /// <summary>Align to direction (float).</summary>
     AlignToDirection = 0x17B78AF6,
+    /// <summary>Drop shadow strength (float).</summary>
     DropShadowStrength = 0x1B1AB4D5,
+    /// <summary>Contour smoothing (float).</summary>
     ContourSmoothing = 0x1E27DCCD,
+    /// <summary>Blend operation (float).</summary>
     BlendOperation = 0x2D13B939,
+    /// <summary>Rotation speed (float).</summary>
     RotationSpeed = 0x32003AD4,
+    /// <summary>Dimming radius (float).</summary>
     DimmingRadius = 0x32DFA298,
+    /// <summary>Is generic box flag (float).</summary>
     IsGenericBox = 0x347C9E07,
+    /// <summary>Is solid object flag (float).</summary>
     IsSolidObject = 0x3BBF99CF,
+    /// <summary>Normal map scale (float).</summary>
     NormalMapScale = 0x3C45E334,
+    /// <summary>No automatic daylight dimming flag (float).</summary>
     NoAutomaticDaylightDimming = 0x3CB5FA70,
+    /// <summary>Frames per second (float).</summary>
     FramesPerSecond = 0x406ADE00,
+    /// <summary>Bloom factor (float).</summary>
     BloomFactor = 0x4168508B,
+    /// <summary>Emissive bloom multiplier (float).</summary>
     EmissiveBloomMultiplier = 0x490E6EB4,
+    /// <summary>Is object flag (float).</summary>
     IsObject = 0x4C12ECE8,
+    /// <summary>Is partition flag (float).</summary>
     IsPartition = 0x5250023D,
+    /// <summary>Ripple speed (float).</summary>
     RippleSpeed = 0x52DEC070,
+    /// <summary>Use lamp color flag (float).</summary>
     UseLampColor = 0x56B220CD,
+    /// <summary>Texture speed scale (float).</summary>
     TextureSpeedScale = 0x583DF357,
+    /// <summary>Noise map scale (float).</summary>
     NoiseMapScale = 0x5E86DEA1,
+    /// <summary>Auto rainbow flag (float).</summary>
     AutoRainbow = 0x5F7800EA,
+    /// <summary>Debounce power (float).</summary>
     DebouncePower = 0x656025DF,
+    /// <summary>Speed stretch factor (float).</summary>
     SpeedStretchFactor = 0x66479028,
+    /// <summary>Wind speed (float).</summary>
     WindSpeed = 0x66E9B6BC,
+    /// <summary>Daytime only flag (float).</summary>
     DaytimeOnly = 0x6BB389BC,
+    /// <summary>Frames random start factor (float).</summary>
     FramesRandomStartFactor = 0x7211F24F,
+    /// <summary>Deflection threshold (float).</summary>
     DeflectionThreshold = 0x7D621D61,
+    /// <summary>Lifetime in seconds (float).</summary>
     LifetimeSeconds = 0x84212733,
+    /// <summary>Normal bump scale (float).</summary>
     NormalBumpScale = 0x88C64AE2,
+    /// <summary>Deformer offset (float).</summary>
     DeformerOffset = 0x8BDF4746,
+    /// <summary>Edge darkening (float).</summary>
     EdgeDarkening = 0x8C27D8C9,
+    /// <summary>Override factor (float).</summary>
     OverrideFactor = 0x8E35CCC0,
+    /// <summary>Emissive light multiplier (float).</summary>
     EmissiveLightMultiplier = 0x8EF71C85,
+    /// <summary>Sharp specular threshold (float).</summary>
     SharpSpecThreshold = 0x903BE4D3,
+    /// <summary>Rug sort (float).</summary>
     RugSort = 0x906997A9,
+    /// <summary>Layer 2 shift (float).</summary>
     Layer2Shift = 0x92692CB2,
+    /// <summary>Specular style (float).</summary>
     SpecStyle = 0x9554D40F,
+    /// <summary>Fade distance (float).</summary>
     FadeDistance = 0x957210EA,
+    /// <summary>Blend destination mode (float).</summary>
     BlendDestMode = 0x9BDECB37,
+    /// <summary>Lighting enabled flag (float).</summary>
     LightingEnabled = 0xA15E4594,
+    /// <summary>Override speed (float).</summary>
     OverrideSpeed = 0xA3D6342E,
+    /// <summary>Visible only at night flag (float).</summary>
     VisibleOnlyAtNight = 0xAC5D0A82,
+    /// <summary>Use diffuse for alpha test flag (float).</summary>
     UseDiffuseForAlphaTest = 0xB597FA7F,
+    /// <summary>Sparkle speed (float).</summary>
     SparkleSpeed = 0xBA13921E,
+    /// <summary>Wind strength (float).</summary>
     WindStrength = 0xBC4A2544,
+    /// <summary>Halo blur (float).</summary>
     HaloBlur = 0xC3AD4F50,
+    /// <summary>Refraction distortion scale (float).</summary>
     RefractionDistortionScale = 0xC3C472A1,
+    /// <summary>Diffuse map UV channel (float).</summary>
     DiffuseMapUVChannel = 0xC45A5F41,
+    /// <summary>Specular map UV channel (float).</summary>
     SpecularMapUVChannel = 0xCB053686,
+    /// <summary>Particle count (float).</summary>
     ParticleCount = 0xCC31B828,
+    /// <summary>Ripple distance scale (float).</summary>
     RippleDistanceScale = 0xCCB35B98,
+    /// <summary>Divet scale (float).</summary>
     DivetScale = 0xCE8C8311,
+    /// <summary>Force amount (float).</summary>
     ForceAmount = 0xD4D51D02,
+    /// <summary>Animation speed (float).</summary>
     AnimSpeed = 0xD600CB63,
+    /// <summary>Back face diffuse contribution (float).</summary>
     BackFaceDiffuseContribution = 0xD641A1B1,
+    /// <summary>Bounce amount in meters (float).</summary>
     BounceAmountMeters = 0xD8542D8B,
+    /// <summary>Is floor flag (float).</summary>
     IsFloor = 0xD9C05335,
+    /// <summary>Bloom scale (float).</summary>
     BloomScale = 0xE29BA4AC,
+    /// <summary>Alpha mask threshold (float).</summary>
     AlphaMaskThreshold = 0xE77A2B60,
+    /// <summary>Lighting direct scale (float).</summary>
     LightingDirectScale = 0xEF270EE4,
+    /// <summary>Always on flag (float).</summary>
     AlwaysOn = 0xF019641D,
+    /// <summary>Shininess (float).</summary>
     Shininess = 0xF755F7FF,
+    /// <summary>Fresnel offset (float).</summary>
     FresnelOffset = 0xFB66A8CB,
+    /// <summary>Bounce power (float).</summary>
     BouncePower = 0xFBA6B898,
+    /// <summary>Shadow alpha test (float).</summary>
     ShadowAlphaTest = 0xFEB1F9CB,
 
     // Float2 fields
+    /// <summary>Diffuse UV scale (float2).</summary>
     DiffuseUVScale = 0x2D4E507E,
+    /// <summary>Ripple heights (float2).</summary>
     RippleHeights = 0x6A07D7E1,
+    /// <summary>Cutout valid heights (float2).</summary>
     CutoutValidHeights = 0x6D43D7B7,
+    /// <summary>UV tiling (float2).</summary>
     UVTiling = 0x773CAB85,
+    /// <summary>Size scale end (float2).</summary>
     SizeScaleEnd = 0x891A3133,
+    /// <summary>Stretch rectangle (float2).</summary>
     StretchRect = 0x8D38D12E,
+    /// <summary>Size scale start (float2).</summary>
     SizeScaleStart = 0x9A6C2EC8,
+    /// <summary>Water scroll speed layer 2 (float2).</summary>
     WaterScrollSpeedLayer2 = 0xAFA11435,
+    /// <summary>Water scroll speed layer 1 (float2).</summary>
     WaterScrollSpeedLayer1 = 0xAFA11436,
+    /// <summary>Normal UV scale (float2).</summary>
     NormalUVScale = 0xBA2D1AB9,
+    /// <summary>Detail UV scale (float2).</summary>
     DetailUVScale = 0xCD985A0B,
+    /// <summary>Specular UV scale (float2).</summary>
     SpecularUVScale = 0xF12E27C3,
+    /// <summary>UV scroll speed (float2).</summary>
     UVScrollSpeed = 0xF2EEA6EC,
 
     // Float3 fields
+    /// <summary>Override direction (float3).</summary>
     OverrideDirection = 0x0C12DED8,
+    /// <summary>Override velocity (float3).</summary>
     OverrideVelocity = 0x14677578,
+    /// <summary>Counter matrix row 1 (float3).</summary>
     CounterMatrixRow1 = 0x1EF8655D,
+    /// <summary>Counter matrix row 2 (float3).</summary>
     CounterMatrixRow2 = 0x1EF8655E,
+    /// <summary>Force direction (float3).</summary>
     ForceDirection = 0x29881F55,
+    /// <summary>Specular color (float3).</summary>
     Specular = 0x2CE11842,
+    /// <summary>Halo low color (float3).</summary>
     HaloLowColor = 0x2EB8E8D4,
+    /// <summary>Normal map UV selector (float3).</summary>
     NormalMapUVSelector = 0x415368B4,
+    /// <summary>UV scales (float3).</summary>
     UVScales = 0x420520E9,
+    /// <summary>Light map scale (float3).</summary>
     LightMapScale = 0x4F7DCB9B,
+    /// <summary>Diffuse color (float3).</summary>
     Diffuse = 0x637DAA05,
+    /// <summary>Ambient UV selector (float3).</summary>
     AmbientUVSelector = 0x797F8E81,
+    /// <summary>Highlight color (float3).</summary>
     HighlightColor = 0x90F8DCF0,
+    /// <summary>Diffuse UV selector (float3).</summary>
     DiffuseUVSelector = 0x91EEBAFF,
+    /// <summary>Vertex color scale (float3).</summary>
     VertexColorScale = 0xA2FD73CA,
+    /// <summary>Specular UV selector (float3).</summary>
     SpecularUVSelector = 0xB63546AC,
+    /// <summary>Emission map UV selector (float3).</summary>
     EmissionMapUVSelector = 0xBC823DDC,
+    /// <summary>Halo high color (float3).</summary>
     HaloHighColor = 0xD4043258,
+    /// <summary>Root color (float3).</summary>
     RootColor = 0xE90599F6,
+    /// <summary>Force vector (float3).</summary>
     ForceVector = 0xEBA4727B,
+    /// <summary>Position tweak (float3).</summary>
     PositionTweak = 0xEF36D180,
 
     // Float4 fields
+    /// <summary>Timeline length (float4).</summary>
     TimelineLength = 0x0081AE98,
+    /// <summary>UV scale (float4).</summary>
     UVScale = 0x159BA53E,
+    /// <summary>Frame data (float4).</summary>
     FrameData = 0x1E5B2324,
+    /// <summary>Animation direction (float4).</summary>
     AnimDir = 0x3F89C2EF,
+    /// <summary>Position scale (float4).</summary>
     PosScale = 0x487648E5,
+    /// <summary>Births (float4).</summary>
     Births = 0x568E0367,
+    /// <summary>UV offset (float4).</summary>
     UVOffset = 0x57582869,
+    /// <summary>Position offset (float4).</summary>
     PosOffset = 0x790EBF2C,
 
     // Int fields
+    /// <summary>Average color (int).</summary>
     AverageColor = 0x449A3A67,
+    /// <summary>Mask width (int).</summary>
     MaskWidth = 0x707F712F,
+    /// <summary>Mask height (int).</summary>
     MaskHeight = 0x849CDADC,
 
     // Texture fields
+    /// <summary>Sparkle cube texture.</summary>
     SparkleCube = 0x1D90C086,
+    /// <summary>Drop shadow atlas texture.</summary>
     DropShadowAtlas = 0x22AD8507,
+    /// <summary>Dirt overlay texture.</summary>
     DirtOverlay = 0x48372E62,
+    /// <summary>Overlay texture.</summary>
     OverlayTexture = 0x4DC0C8BC,
+    /// <summary>Jet texture.</summary>
     JetTexture = 0x52CE211B,
+    /// <summary>Color ramp texture.</summary>
     ColorRamp = 0x581835D6,
+    /// <summary>Diffuse map texture.</summary>
     DiffuseMap = 0x6CC0FD85,
+    /// <summary>Self-illumination map texture.</summary>
     SelfIlluminationMap = 0x6E067554,
+    /// <summary>Normal map texture.</summary>
     NormalMap = 0x6E56548A,
+    /// <summary>Halo ramp texture.</summary>
     HaloRamp = 0x84F6E0FB,
+    /// <summary>Detail map texture.</summary>
     DetailMap = 0x9205DAA8,
+    /// <summary>Specular map texture.</summary>
     SpecularMap = 0xAD528A60,
+    /// <summary>Ambient occlusion map texture.</summary>
     AmbientOcclusionMap = 0xB01CBA60,
+    /// <summary>Alpha map texture.</summary>
     AlphaMap = 0xC3FAAC4F,
+    /// <summary>Multiply map texture.</summary>
     MultiplyMap = 0xCD869A45,
+    /// <summary>Specular composite texture.</summary>
     SpecCompositeTexture = 0xD652FADE,
+    /// <summary>Noise map texture.</summary>
     NoiseMap = 0xE19FD579,
+    /// <summary>Room light map texture.</summary>
     RoomLightMap = 0xE7CA9166,
+    /// <summary>Emission map texture.</summary>
     EmissionMap = 0xF303D152,
+    /// <summary>Reveal map texture.</summary>
     RevealMap = 0xF3F22AC4,
 
     // TextureKey fields
+    /// <summary>Imposter texture with ambient occlusion and self-illumination.</summary>
     ImposterTextureAOandSI = 0x15C9D298,
+    /// <summary>Impostor detail texture.</summary>
     ImpostorDetailTexture = 0x56E1C6B2,
+    /// <summary>Imposter texture.</summary>
     ImposterTexture = 0xBDCF71C5,
+    /// <summary>Imposter texture for water.</summary>
     ImposterTextureWater = 0xBF3FB9FA,
 }
 

--- a/src/TS4Tools.Wrappers/ObjKeyResource/ObjKeyResource.cs
+++ b/src/TS4Tools.Wrappers/ObjKeyResource/ObjKeyResource.cs
@@ -399,21 +399,84 @@ public sealed class ObjKeyResource : TypedResource
 /// </summary>
 public enum ObjKeyComponent : uint
 {
+    /// <summary>
+    /// Animation component.
+    /// </summary>
     Animation = 0xee17c6ad,
+
+    /// <summary>
+    /// Effect component.
+    /// </summary>
     Effect = 0x80d91e9e,
+
+    /// <summary>
+    /// Footprint component.
+    /// </summary>
     Footprint = 0xc807312a,
+
+    /// <summary>
+    /// Lighting component.
+    /// </summary>
     Lighting = 0xda6c50fd,
+
+    /// <summary>
+    /// Location component.
+    /// </summary>
     Location = 0x461922c8,
+
+    /// <summary>
+    /// Lot object component.
+    /// </summary>
     LotObject = 0x6693c8b3,
+
+    /// <summary>
+    /// Model component.
+    /// </summary>
     Model = 0x2954e734,
+
+    /// <summary>
+    /// Physics component.
+    /// </summary>
     Physics = 0x1a8feb14,
+
+    /// <summary>
+    /// SACS component.
+    /// </summary>
     Sacs = 0x3ae9a8e7,
+
+    /// <summary>
+    /// Script component.
+    /// </summary>
     Script = 0x23177498,
+
+    /// <summary>
+    /// Sim component.
+    /// </summary>
     Sim = 0x22706efa,
+
+    /// <summary>
+    /// Slot component.
+    /// </summary>
     Slot = 0x2ef1e401,
+
+    /// <summary>
+    /// Steering component.
+    /// </summary>
     Steering = 0x61bd317c,
+
+    /// <summary>
+    /// Transform component.
+    /// </summary>
     Transform = 0x54cb7ebb,
+
+    /// <summary>
+    /// Tree component.
+    /// </summary>
     Tree = 0xc602cd31,
+
+    /// <summary>
+    /// Visual state component.
+    /// </summary>
     VisualState = 0x50b3d17c,
 }
 

--- a/src/TS4Tools.Wrappers/RigResource/IkChain.cs
+++ b/src/TS4Tools.Wrappers/RigResource/IkChain.cs
@@ -146,6 +146,7 @@ public sealed class IkChain : IEquatable<IkChain>
     /// Calculates the serialized size of this IK chain.
     /// </summary>
     /// <param name="majorVersion">The rig major version.</param>
+    /// <returns>The total size in bytes when serialized.</returns>
     public int GetSerializedSize(uint majorVersion)
     {
         int size = 4 + (Bones.Count * 4); // Bone list
@@ -163,6 +164,11 @@ public sealed class IkChain : IEquatable<IkChain>
         return size;
     }
 
+    /// <summary>
+    /// Determines whether this IK chain is equal to another IK chain.
+    /// </summary>
+    /// <param name="other">The IK chain to compare with.</param>
+    /// <returns>True if the IK chains are equal; otherwise, false.</returns>
     public bool Equals(IkChain? other)
     {
         if (other is null) return false;
@@ -181,8 +187,17 @@ public sealed class IkChain : IEquatable<IkChain>
             && RootIndex == other.RootIndex;
     }
 
+    /// <summary>
+    /// Determines whether this IK chain is equal to the specified object.
+    /// </summary>
+    /// <param name="obj">The object to compare with.</param>
+    /// <returns>True if the objects are equal; otherwise, false.</returns>
     public override bool Equals(object? obj) => obj is IkChain other && Equals(other);
 
+    /// <summary>
+    /// Returns a hash code for this IK chain.
+    /// </summary>
+    /// <returns>A hash code for the current IK chain.</returns>
     public override int GetHashCode()
     {
         var hash = new HashCode();
@@ -196,5 +211,9 @@ public sealed class IkChain : IEquatable<IkChain>
         return hash.ToHashCode();
     }
 
+    /// <summary>
+    /// Returns a string representation of this IK chain.
+    /// </summary>
+    /// <returns>A string describing the IK chain.</returns>
     public override string ToString() => $"IkChain ({Bones.Count} bones)";
 }

--- a/src/TS4Tools.Wrappers/RigResource/RigBone.cs
+++ b/src/TS4Tools.Wrappers/RigResource/RigBone.cs
@@ -48,6 +48,9 @@ public sealed class RigBone : IEquatable<RigBone>
     /// Reads a bone from the data span.
     /// Source: RigResource.cs Bone.Parse() lines 207-218
     /// </summary>
+    /// <param name="data">The data span to read from.</param>
+    /// <param name="position">Current position, updated after reading.</param>
+    /// <returns>The parsed bone.</returns>
     public static RigBone Read(ReadOnlySpan<byte> data, ref int position)
     {
         var bone = new RigBone
@@ -89,6 +92,8 @@ public sealed class RigBone : IEquatable<RigBone>
     /// Writes the bone to the buffer.
     /// Source: RigResource.cs Bone.UnParse() lines 220-236
     /// </summary>
+    /// <param name="buffer">The buffer to write to.</param>
+    /// <param name="position">Current position, updated after writing.</param>
     public void Write(Span<byte> buffer, ref int position)
     {
         Position.Write(buffer, ref position);
@@ -122,6 +127,7 @@ public sealed class RigBone : IEquatable<RigBone>
     /// <summary>
     /// Calculates the serialized size of this bone.
     /// </summary>
+    /// <returns>The total size in bytes when serialized.</returns>
     public int GetSerializedSize()
     {
         // Position(12) + Orientation(16) + Scaling(12) + NameLength(4) + Name + indices(16)
@@ -129,6 +135,11 @@ public sealed class RigBone : IEquatable<RigBone>
         return 12 + 16 + 12 + 4 + nameBytes + 16;
     }
 
+    /// <summary>
+    /// Determines whether this bone is equal to another bone.
+    /// </summary>
+    /// <param name="other">The bone to compare with.</param>
+    /// <returns>True if the bones are equal; otherwise, false.</returns>
     public bool Equals(RigBone? other)
     {
         if (other is null) return false;
@@ -142,10 +153,23 @@ public sealed class RigBone : IEquatable<RigBone>
             && Unknown2 == other.Unknown2;
     }
 
+    /// <summary>
+    /// Determines whether this bone is equal to the specified object.
+    /// </summary>
+    /// <param name="obj">The object to compare with.</param>
+    /// <returns>True if the objects are equal; otherwise, false.</returns>
     public override bool Equals(object? obj) => obj is RigBone other && Equals(other);
 
+    /// <summary>
+    /// Returns a hash code for this bone.
+    /// </summary>
+    /// <returns>A hash code for the current bone.</returns>
     public override int GetHashCode() =>
         HashCode.Combine(Position, Orientation, Scaling, Name, OpposingBoneIndex, ParentBoneIndex, Hash, Unknown2);
 
+    /// <summary>
+    /// Returns a string representation of this bone.
+    /// </summary>
+    /// <returns>A string describing the bone.</returns>
     public override string ToString() => $"Bone '{Name}' (0x{Hash:X8})";
 }

--- a/src/TS4Tools.Wrappers/TS4Tools.Wrappers.csproj
+++ b/src/TS4Tools.Wrappers/TS4Tools.Wrappers.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <RootNamespace>TS4Tools.Wrappers</RootNamespace>
     <Description>Resource type wrappers for TS4Tools - STBL, NameMap, and more</Description>
-    <!-- Suppress missing XML docs until wrapper documentation is complete -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TS4Tools.Wrappers/TxtcResource/TxtcResource.cs
+++ b/src/TS4Tools.Wrappers/TxtcResource/TxtcResource.cs
@@ -507,7 +507,14 @@ public sealed class TxtcResource : TypedResource
 /// </summary>
 public enum TxtcPatternSize : uint
 {
+    /// <summary>
+    /// Default pattern size.
+    /// </summary>
     Default = 0x00,
+
+    /// <summary>
+    /// Large pattern size.
+    /// </summary>
     Large = 0x01,
 }
 
@@ -517,16 +524,40 @@ public enum TxtcPatternSize : uint
 [Flags]
 public enum TxtcDataType : uint
 {
+    /// <summary>
+    /// Hair data type.
+    /// </summary>
     Hair = 0x00000001,
+
+    /// <summary>
+    /// Scalp data type.
+    /// </summary>
     Scalp = 0x00000002,
+
+    /// <summary>
+    /// Face overlay data type.
+    /// </summary>
     FaceOverlay = 0x00000004,
+
+    /// <summary>
+    /// Body data type.
+    /// </summary>
     Body = 0x00000008,
+
+    /// <summary>
+    /// Accessory data type.
+    /// </summary>
     Accessory = 0x00000010,
 }
 
 /// <summary>
 /// Super block for version 7+ TXTC resources.
 /// </summary>
+/// <param name="TgiIndex">TGI block index.</param>
+/// <param name="FabricData">Fabric content data.</param>
+/// <param name="Unknown1">Unknown field 1.</param>
+/// <param name="Unknown2">Unknown field 2.</param>
+/// <param name="Unknown3">Unknown field 3.</param>
 public sealed record TxtcSuperBlock(
     byte TgiIndex,
     byte[] FabricData,
@@ -537,79 +568,130 @@ public sealed record TxtcSuperBlock(
 /// <summary>
 /// Entry block containing multiple entries terminated by null.
 /// </summary>
+/// <param name="Entries">List of entries in this block.</param>
 public sealed record TxtcEntryBlock(IReadOnlyList<TxtcEntry> Entries);
 
 /// <summary>
 /// Base class for TXTC entries.
 /// </summary>
+/// <param name="Property">Property identifier.</param>
+/// <param name="Unknown">Unknown field.</param>
 public abstract record TxtcEntry(uint Property, byte Unknown);
 
 /// <summary>
 /// Boolean entry.
 /// </summary>
+/// <param name="Property">Property identifier.</param>
+/// <param name="Unknown">Unknown field.</param>
+/// <param name="Value">Boolean value.</param>
 public sealed record TxtcEntryBoolean(uint Property, byte Unknown, bool Value) : TxtcEntry(Property, Unknown);
 
 /// <summary>
 /// Signed byte entry.
 /// </summary>
+/// <param name="Property">Property identifier.</param>
+/// <param name="Unknown">Unknown field.</param>
+/// <param name="Value">Signed byte value.</param>
 public sealed record TxtcEntrySByte(uint Property, byte Unknown, sbyte Value) : TxtcEntry(Property, Unknown);
 
 /// <summary>
 /// Unsigned byte entry.
 /// </summary>
+/// <param name="Property">Property identifier.</param>
+/// <param name="Unknown">Unknown field.</param>
+/// <param name="Value">Unsigned byte value.</param>
 public sealed record TxtcEntryByte(uint Property, byte Unknown, byte Value) : TxtcEntry(Property, Unknown);
 
 /// <summary>
 /// TGI index entry.
 /// </summary>
+/// <param name="Property">Property identifier.</param>
+/// <param name="Unknown">Unknown field.</param>
+/// <param name="Value">TGI block index value.</param>
 public sealed record TxtcEntryTgiIndex(uint Property, byte Unknown, byte Value) : TxtcEntry(Property, Unknown);
 
 /// <summary>
 /// Int16 entry.
 /// </summary>
+/// <param name="Property">Property identifier.</param>
+/// <param name="Unknown">Unknown field.</param>
+/// <param name="Value">Int16 value.</param>
 public sealed record TxtcEntryInt16(uint Property, byte Unknown, short Value) : TxtcEntry(Property, Unknown);
 
 /// <summary>
 /// UInt16 entry.
 /// </summary>
+/// <param name="Property">Property identifier.</param>
+/// <param name="Unknown">Unknown field.</param>
+/// <param name="Value">UInt16 value.</param>
 public sealed record TxtcEntryUInt16(uint Property, byte Unknown, ushort Value) : TxtcEntry(Property, Unknown);
 
 /// <summary>
 /// Int32 entry.
 /// </summary>
+/// <param name="Property">Property identifier.</param>
+/// <param name="Unknown">Unknown field.</param>
+/// <param name="Value">Int32 value.</param>
 public sealed record TxtcEntryInt32(uint Property, byte Unknown, int Value) : TxtcEntry(Property, Unknown);
 
 /// <summary>
 /// UInt32 entry.
 /// </summary>
+/// <param name="Property">Property identifier.</param>
+/// <param name="Unknown">Unknown field.</param>
+/// <param name="Value">UInt32 value.</param>
 public sealed record TxtcEntryUInt32(uint Property, byte Unknown, uint Value) : TxtcEntry(Property, Unknown);
 
 /// <summary>
 /// Int64 entry.
 /// </summary>
+/// <param name="Property">Property identifier.</param>
+/// <param name="Unknown">Unknown field.</param>
+/// <param name="Value">Int64 value.</param>
 public sealed record TxtcEntryInt64(uint Property, byte Unknown, long Value) : TxtcEntry(Property, Unknown);
 
 /// <summary>
 /// UInt64 entry.
 /// </summary>
+/// <param name="Property">Property identifier.</param>
+/// <param name="Unknown">Unknown field.</param>
+/// <param name="Value">UInt64 value.</param>
 public sealed record TxtcEntryUInt64(uint Property, byte Unknown, ulong Value) : TxtcEntry(Property, Unknown);
 
 /// <summary>
 /// Single (float) entry.
 /// </summary>
+/// <param name="Property">Property identifier.</param>
+/// <param name="Unknown">Unknown field.</param>
+/// <param name="Value">Single (float) value.</param>
 public sealed record TxtcEntrySingle(uint Property, byte Unknown, float Value) : TxtcEntry(Property, Unknown);
 
 /// <summary>
 /// Rectangle entry (4 floats).
 /// </summary>
+/// <param name="Property">Property identifier.</param>
+/// <param name="Unknown">Unknown field.</param>
+/// <param name="X">X coordinate.</param>
+/// <param name="Y">Y coordinate.</param>
+/// <param name="Width">Width dimension.</param>
+/// <param name="Height">Height dimension.</param>
 public sealed record TxtcEntryRectangle(uint Property, byte Unknown, float X, float Y, float Width, float Height) : TxtcEntry(Property, Unknown);
 
 /// <summary>
 /// Vector entry (4 floats).
 /// </summary>
+/// <param name="Property">Property identifier.</param>
+/// <param name="Unknown">Unknown field.</param>
+/// <param name="X">X component.</param>
+/// <param name="Y">Y component.</param>
+/// <param name="Z">Z component.</param>
+/// <param name="W">W component.</param>
 public sealed record TxtcEntryVector(uint Property, byte Unknown, float X, float Y, float Z, float W) : TxtcEntry(Property, Unknown);
 
 /// <summary>
 /// String entry.
 /// </summary>
+/// <param name="Property">Property identifier.</param>
+/// <param name="Unknown">Unknown field.</param>
+/// <param name="Value">String value.</param>
 public sealed record TxtcEntryString(uint Property, byte Unknown, string Value) : TxtcEntry(Property, Unknown);


### PR DESCRIPTION
Adds comprehensive XML documentation comments to all public members in the Wrappers library to satisfy compiler documentation requirements when TreatWarningsAsErrors is enabled. This enables proper NuGet package documentation and IntelliSense support.

Files updated:
- CasPartResource: CaspEnums.cs, SimOutfitResource.cs
- CatalogResource: CatalogCommon.cs, CwalResource.cs
- ImageResource: DxtDecoder.cs
- JazzChunks: JazzConstants.cs, JazzCommon.cs, block files
- MeshChunks: Blocks, Common types, Geometry, ShaderData
- ObjKeyResource: ObjKeyResource.cs
- RigResource: IkChain.cs, RigBone.cs
- TxtcResource: TxtcResource.cs

Also removes CS1591 suppression from TS4Tools.Wrappers.csproj now that all public members are documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)